### PR TITLE
feat(helm): upgrade releases with chart source and values

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -51,6 +51,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
+    "esbuild": "^0.28.2",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",
     "vite": "^8.2.1",

--- a/apps/desktop/playwright.live.config.ts
+++ b/apps/desktop/playwright.live.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test";
+
+/**
+ * Live web harness: drives the renderer served by the already-running
+ * `pnpm dev` Vite server (127.0.0.1:5173) against the real sidecar. No
+ * webServer block — the dev session must already be up; scripts/test-live-web.sh
+ * verifies that and injects the sidecar coordinates.
+ */
+export default defineConfig({
+  testDir: "./tests/live",
+  timeout: 90_000,
+  workers: 1,
+  use: {
+    baseURL: process.env.ASTER_LIVE_BASE_URL ?? "http://127.0.0.1:5173",
+  },
+  reporter: [["list"]],
+});

--- a/apps/desktop/scripts/test-live-web.sh
+++ b/apps/desktop/scripts/test-live-web.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Runs the live web tests (tests/live) against the currently running
+# `pnpm dev` session: discovers the sidecar's loopback port and bearer token
+# from its process environment and hands them to Playwright via env vars.
+# The token never touches disk or stdout.
+set -eu
+
+cd "$(dirname "$0")/.."
+
+SIDECAR_PID=$(pgrep -f "target/debug/aster-core" | head -1 || true)
+if [ -z "$SIDECAR_PID" ]; then
+  echo "no running aster-core sidecar found; start \`pnpm dev\` first" >&2
+  exit 1
+fi
+
+# lsof ORs its selection criteria unless -a is given; without it the first
+# listening socket of ANY process would be picked.
+PORT=$(lsof -a -nP -iTCP -sTCP:LISTEN -p "$SIDECAR_PID" | awk '/127\.0\.0\.1/ { sub(/.*:/, "", $9); print $9; exit }')
+TOKEN=$(ps -Eww -p "$SIDECAR_PID" -o command | tr ' ' '\n' | sed -n 's/^ASTER_BOOTSTRAP_TOKEN=//p' | head -1)
+
+if [ -z "$PORT" ] || [ -z "$TOKEN" ]; then
+  echo "could not read sidecar port/token from pid $SIDECAR_PID" >&2
+  exit 1
+fi
+
+ASTER_LIVE_CORE_URL="http://127.0.0.1:$PORT" \
+ASTER_LIVE_TOKEN="$TOKEN" \
+exec pnpm exec playwright test --config playwright.live.config.ts "$@"

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -167,12 +167,14 @@ pub async fn helm_releases_uninstall(state: State<'_, AppState>, request: Value)
 
 #[tauri::command]
 pub async fn helm_releases_rollback(state: State<'_, AppState>, request: Value) -> Result<Value, String> {
-    state.core.post("/v1/helm/releases/rollback", request).await
+    // Rollback re-applies a stored manifest and can outlast the 30s default.
+    state.core.post_long("/v1/helm/releases/rollback", request).await
 }
 
 #[tauri::command]
 pub async fn helm_releases_upgrade(state: State<'_, AppState>, request: Value) -> Result<Value, String> {
-    state.core.post("/v1/helm/releases/upgrade", request).await
+    // Upgrades re-apply manifests and can outlast the 30s default.
+    state.core.post_long("/v1/helm/releases/upgrade", request).await
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -171,6 +171,11 @@ pub async fn helm_releases_rollback(state: State<'_, AppState>, request: Value) 
 }
 
 #[tauri::command]
+pub async fn helm_releases_upgrade(state: State<'_, AppState>, request: Value) -> Result<Value, String> {
+    state.core.post("/v1/helm/releases/upgrade", request).await
+}
+
+#[tauri::command]
 pub async fn pods_portforward_start(state: State<'_, AppState>, request: Value) -> Result<Value, String> {
     state.core.post("/v1/pods/portforward", request).await
 }

--- a/apps/desktop/src-tauri/src/core_client.rs
+++ b/apps/desktop/src-tauri/src/core_client.rs
@@ -23,6 +23,11 @@ impl<R: tauri::Runtime> CredentialProvider for crate::sidecar::Sidecar<R> {
 pub struct CoreClient {
     provider: Arc<dyn CredentialProvider>,
     http: reqwest::Client,
+    /// Long-running mutations (helm upgrade/rollback re-apply manifests and
+    /// legitimately take minutes; the core caps helm operations at five
+    /// minutes). A 30s cap would abort them client-side while the core keeps
+    /// running, so they get their own client with headroom past that cap.
+    http_long: reqwest::Client,
     /// No total timeout: streaming endpoints stay open until cancelled.
     http_stream: reqwest::Client,
 }
@@ -33,18 +38,26 @@ impl CoreClient {
             .timeout(Duration::from_secs(30))
             .build()
             .expect("reqwest client builds with rustls");
+        let http_long = reqwest::Client::builder()
+            .timeout(Duration::from_secs(6 * 60))
+            .build()
+            .expect("reqwest client builds with rustls");
         let http_stream = reqwest::Client::builder()
             .build()
             .expect("reqwest client builds with rustls");
-        Self { provider, http, http_stream }
+        Self { provider, http, http_long, http_stream }
     }
 
     pub async fn get(&self, path: &str) -> Result<Value, String> {
-        self.request(reqwest::Method::GET, path, None).await
+        self.request(&self.http, reqwest::Method::GET, path, None).await
     }
 
     pub async fn post(&self, path: &str, body: Value) -> Result<Value, String> {
-        self.request(reqwest::Method::POST, path, Some(body)).await
+        self.request(&self.http, reqwest::Method::POST, path, Some(body)).await
+    }
+
+    pub async fn post_long(&self, path: &str, body: Value) -> Result<Value, String> {
+        self.request(&self.http_long, reqwest::Method::POST, path, Some(body)).await
     }
 
     pub async fn post_stream(&self, path: &str, body: Value) -> Result<impl Stream<Item = Result<Bytes, reqwest::Error>>, String> {
@@ -66,9 +79,9 @@ impl CoreClient {
         Ok(response.bytes_stream())
     }
 
-    async fn request(&self, method: reqwest::Method, path: &str, body: Option<Value>) -> Result<Value, String> {
+    async fn request(&self, client: &reqwest::Client, method: reqwest::Method, path: &str, body: Option<Value>) -> Result<Value, String> {
         let (base_url, token) = self.provider.credentials()?;
-        let mut request = self.http.request(method, format!("{base_url}{path}")).bearer_auth(token);
+        let mut request = client.request(method, format!("{base_url}{path}")).bearer_auth(token);
         if let Some(body) = body {
             request = request.json(&body);
         }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -109,6 +109,7 @@ pub fn run() {
             commands::helm_releases_get,
             commands::helm_releases_uninstall,
             commands::helm_releases_rollback,
+            commands::helm_releases_upgrade,
             commands::resources_list,
             commands::resources_get,
             commands::resources_related,

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -579,7 +579,6 @@ export default function App() {
               detailLoading={helm.detailLoading}
               detailError={helm.detailError}
               busy={helm.busy}
-              message={helm.message}
               onRefresh={helm.refresh}
               onSelect={(name, releaseNamespace) => void helm.select(name, releaseNamespace)}
               onUninstall={(name) => void helm.uninstall(name)}

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -581,7 +581,7 @@ export default function App() {
               busy={helm.busy}
               message={helm.message}
               onRefresh={helm.refresh}
-              onSelect={(name) => void helm.select(name)}
+              onSelect={(name, releaseNamespace) => void helm.select(name, releaseNamespace)}
               onBack={helm.clear}
               onUninstall={(name) => void helm.uninstall(name)}
               onRollback={(name, revision) => void helm.rollback(name, revision)}

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -585,6 +585,7 @@ export default function App() {
               onBack={helm.clear}
               onUninstall={(name) => void helm.uninstall(name)}
               onRollback={(name, revision) => void helm.rollback(name, revision)}
+              onUpgrade={helm.upgrade}
             />
           )}
           <section className="resource-pane" aria-label={`${kind.kind} resources`} hidden={overviewActive || helmActive || Boolean(detail.selected)}>

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -582,7 +582,6 @@ export default function App() {
               message={helm.message}
               onRefresh={helm.refresh}
               onSelect={(name, releaseNamespace) => void helm.select(name, releaseNamespace)}
-              onBack={helm.clear}
               onUninstall={(name) => void helm.uninstall(name)}
               onRollback={(name, revision) => void helm.rollback(name, revision)}
               onUpgrade={helm.upgrade}

--- a/apps/desktop/src/renderer/components/ui/toast.tsx
+++ b/apps/desktop/src/renderer/components/ui/toast.tsx
@@ -1,0 +1,232 @@
+import * as React from "react"
+import { Toast as ToastPrimitive } from "@base-ui/react/toast"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon, CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const toast = ToastPrimitive.createToastManager()
+
+function ToastProvider({ ...props }: ToastPrimitive.Provider.Props) {
+  return <ToastPrimitive.Provider {...props} />
+}
+
+function ToastPortal({ ...props }: ToastPrimitive.Portal.Props) {
+  return <ToastPrimitive.Portal data-slot="toast-portal" {...props} />
+}
+
+function ToastViewport({ className, ...props }: ToastPrimitive.Viewport.Props) {
+  return (
+    <ToastPrimitive.Viewport
+      data-slot="toast-viewport"
+      className={cn(
+        "pointer-events-none fixed inset-x-4 bottom-4 z-50 mx-auto w-auto max-w-sm outline-none sm:right-4 sm:left-auto sm:mx-0 sm:w-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function Toast({ className, ...props }: ToastPrimitive.Root.Props) {
+  return (
+    <ToastPrimitive.Root
+      data-slot="toast"
+      className={cn(
+        "group/toast pointer-events-auto absolute right-0 bottom-0 z-[calc(1000-var(--toast-index))] w-full origin-bottom rounded-md border bg-popover text-popover-foreground shadow-lg will-change-transform outline-none select-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "[--gap:0.75rem] [--height:var(--toast-frontmost-height,var(--toast-height))] [--offset-y:calc(var(--toast-offset-y)*-1+calc(var(--toast-index)*var(--gap)*-1)+var(--toast-swipe-movement-y))] [--peek:0.75rem] [--scale:calc(max(0,1-(var(--toast-index)*0.1)))] [--shrink:calc(1-var(--scale))]",
+        "h-(--height) [transform:translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-swipe-movement-y)-(var(--toast-index)*var(--peek))-(var(--shrink)*var(--height))))_scale(var(--scale))] [transition:transform_500ms_cubic-bezier(0.22,1,0.36,1),opacity_500ms,height_150ms]",
+        "after:absolute after:top-full after:left-0 after:h-[calc(var(--gap)+1px)] after:w-full after:content-['']",
+        "data-expanded:h-(--toast-height) data-expanded:[transform:translateX(var(--toast-swipe-movement-x))_translateY(var(--offset-y))]",
+        "data-limited:opacity-0 data-starting-style:[transform:translateY(150%)]",
+        "[&[data-ending-style]:not([data-limited]):not([data-swipe-direction])]:[transform:translateY(150%)]",
+        "data-ending-style:data-[swipe-direction=down]:[transform:translateY(calc(var(--toast-swipe-movement-y)+150%))]",
+        "data-ending-style:data-[swipe-direction=left]:[transform:translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))]",
+        "data-ending-style:data-[swipe-direction=right]:[transform:translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))]",
+        "data-ending-style:data-[swipe-direction=up]:[transform:translateY(calc(var(--toast-swipe-movement-y)-150%))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=down]:[transform:translateY(calc(var(--toast-swipe-movement-y)+150%))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=left]:[transform:translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=right]:[transform:translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))]",
+        "data-expanded:data-ending-style:data-[swipe-direction=up]:[transform:translateY(calc(var(--toast-swipe-movement-y)-150%))]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ToastContent({ className, ...props }: ToastPrimitive.Content.Props) {
+  return (
+    <ToastPrimitive.Content
+      data-slot="toast-content"
+      className={cn(
+        "flex h-full items-center gap-3 overflow-hidden p-4 transition-opacity duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] data-behind:opacity-0 data-expanded:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ToastTitle({ className, ...props }: ToastPrimitive.Title.Props) {
+  return (
+    <ToastPrimitive.Title
+      data-slot="toast-title"
+      className={cn("text-sm font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function ToastDescription({
+  className,
+  ...props
+}: ToastPrimitive.Description.Props) {
+  return (
+    <ToastPrimitive.Description
+      data-slot="toast-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function ToastAction({
+  className,
+  render = <Button variant="outline" size="sm" />,
+  ...props
+}: ToastPrimitive.Action.Props) {
+  return (
+    <ToastPrimitive.Action
+      data-slot="toast-action"
+      render={render}
+      className={cn("shrink-0", className)}
+      {...props}
+    />
+  )
+}
+
+function ToastClose({
+  className,
+  children,
+  render = <Button variant="ghost" size="icon-sm" />,
+  ...props
+}: ToastPrimitive.Close.Props) {
+  return (
+    <ToastPrimitive.Close
+      data-slot="toast-close"
+      aria-label="Close toast"
+      render={render}
+      className={cn(
+        "relative shrink-0 text-muted-foreground after:absolute after:-inset-2 after:content-[''] hover:text-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children ?? (
+        <XIcon aria-hidden="true" />
+      )}
+    </ToastPrimitive.Close>
+  )
+}
+
+function ToastIcon({ type }: { type: string | undefined }) {
+  let icon: React.ReactNode = null
+
+  if (type === "success") {
+    icon = (
+      <CircleCheckIcon aria-hidden="true" />
+    )
+  }
+
+  if (type === "info") {
+    icon = (
+      <InfoIcon aria-hidden="true" />
+    )
+  }
+
+  if (type === "warning") {
+    icon = (
+      <TriangleAlertIcon aria-hidden="true" />
+    )
+  }
+
+  if (type === "error") {
+    icon = (
+      <OctagonXIcon className="text-destructive" aria-hidden="true" />
+    )
+  }
+
+  if (type === "loading") {
+    icon = (
+      <Loader2Icon className="animate-spin" aria-hidden="true" />
+    )
+  }
+
+  if (!icon) {
+    return null
+  }
+
+  return (
+    <span
+      data-slot="toast-icon"
+      className="shrink-0 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4"
+    >
+      {icon}
+    </span>
+  )
+}
+
+function ToastList() {
+  const { toasts } = ToastPrimitive.useToastManager()
+
+  return toasts.map((toastItem) => (
+    <Toast key={toastItem.id} toast={toastItem}>
+      <ToastContent>
+        <ToastIcon type={toastItem.type} />
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <ToastTitle />
+          <ToastDescription />
+        </div>
+        <ToastAction />
+        <ToastClose />
+      </ToastContent>
+    </Toast>
+  ))
+}
+
+function Toaster({
+  children,
+  toastManager = toast,
+  ...props
+}: ToastPrimitive.Provider.Props) {
+  return (
+    <ToastProvider toastManager={toastManager} {...props}>
+      {children}
+      <ToastPortal>
+        <ToastViewport>
+          <ToastList />
+        </ToastViewport>
+      </ToastPortal>
+    </ToastProvider>
+  )
+}
+
+const createToastManager = ToastPrimitive.createToastManager
+const useToastManager = ToastPrimitive.useToastManager
+
+export {
+  Toaster,
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastContent,
+  ToastDescription,
+  ToastPortal,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+  createToastManager,
+  toast,
+  useToastManager,
+}

--- a/apps/desktop/src/renderer/detail/ResourceDetailView.tsx
+++ b/apps/desktop/src/renderer/detail/ResourceDetailView.tsx
@@ -523,6 +523,7 @@ function YamlResourceEditor({
       <textarea
         className="resource-yaml-editor"
         value={yaml}
+        wrap="off"
         readOnly={!canMutate || mutationBusy}
         aria-readonly={!canMutate || mutationBusy}
         spellCheck={false}

--- a/apps/desktop/src/renderer/hooks/useHelm.ts
+++ b/apps/desktop/src/renderer/hooks/useHelm.ts
@@ -48,6 +48,14 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
   const [generation, setGeneration] = useState(0);
   const request = useRef(0);
 
+  // Same scope-reset contract as useResourceDetail: when the list scope
+  // (context or namespace) changes, close any open release detail so a stale
+  // cross-namespace read can't linger under a picker that says otherwise.
+  useEffect(() => {
+    setSelected(undefined);
+    setDetailError("");
+  }, [contextId, namespace]);
+
   useEffect(() => {
     if (!contextId || !coreReady) return;
     const current = ++request.current;

--- a/apps/desktop/src/renderer/hooks/useHelm.ts
+++ b/apps/desktop/src/renderer/hooks/useHelm.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { HelmReleaseDetail, HelmReleaseSummary } from "../../shared/types";
+import type { HelmReleaseDetail, HelmReleaseSummary, HelmUpgradeRequest } from "../../shared/types";
 import { desktop } from "../lib/desktop";
 
 export interface UseHelmOptions {
@@ -7,6 +7,8 @@ export interface UseHelmOptions {
   namespace: string;
   coreReady: boolean;
 }
+
+export type HelmUpgradeInput = Omit<HelmUpgradeRequest, "contextId" | "namespace">;
 
 export interface HelmState {
   releases: HelmReleaseSummary[];
@@ -24,6 +26,8 @@ export interface HelmState {
   clear(): void;
   uninstall(name: string): Promise<void>;
   rollback(name: string, revision?: number): Promise<void>;
+  /** Resolves true when the upgrade succeeded so the dialog can close. */
+  upgrade(input: HelmUpgradeInput): Promise<boolean>;
 }
 
 /**
@@ -118,6 +122,25 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
     }
   }, [contextId, namespace, busy, refresh]);
 
+  const upgrade = useCallback(async (input: HelmUpgradeInput): Promise<boolean> => {
+    if (!contextId || !namespace || busy) return false;
+    setBusy(true);
+    setMessage("");
+    setDetailError("");
+    try {
+      const response = await desktop.helm.upgrade({ contextId, namespace, ...input });
+      setMessage(`Release "${input.name}" upgraded to revision ${response.revision}`);
+      await select(input.name);
+      refresh();
+      return true;
+    } catch (cause) {
+      setDetailError(cause instanceof Error ? cause.message : String(cause));
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }, [contextId, namespace, busy, select, refresh]);
+
   return {
     releases,
     loading,
@@ -133,5 +156,6 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
     clear,
     uninstall,
     rollback,
+    upgrade,
   };
 }

--- a/apps/desktop/src/renderer/hooks/useHelm.ts
+++ b/apps/desktop/src/renderer/hooks/useHelm.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { HelmReleaseDetail, HelmReleaseSummary, HelmUpgradeRequest } from "../../shared/types";
+import { toast } from "@/components/ui/toast";
 import { desktop } from "../lib/desktop";
 
 export interface UseHelmOptions {
@@ -18,7 +19,6 @@ export interface HelmState {
   detailLoading: boolean;
   detailError: string;
   busy: boolean;
-  message: string;
   /** Bumps on every explicit refresh so the list effect re-fetches. */
   generation: number;
   refresh(): void;
@@ -26,8 +26,8 @@ export interface HelmState {
   clear(): void;
   uninstall(name: string): Promise<void>;
   rollback(name: string, revision?: number): Promise<void>;
-  /** Resolves true when the upgrade succeeded so the dialog can close. */
-  upgrade(input: HelmUpgradeInput): Promise<boolean>;
+  /** Resolves null on success so the dialog can close, or the error message. */
+  upgrade(input: HelmUpgradeInput): Promise<string | null>;
 }
 
 /**
@@ -44,7 +44,6 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState("");
   const [busy, setBusy] = useState(false);
-  const [message, setMessage] = useState("");
   const [generation, setGeneration] = useState(0);
   const request = useRef(0);
 
@@ -102,11 +101,10 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
     const ns = selected?.namespace || namespace;
     if (!contextId || !ns || busy) return;
     setBusy(true);
-    setMessage("");
     setDetailError("");
     try {
       await desktop.helm.uninstall({ contextId, namespace: ns, name });
-      setMessage(`Release "${name}" uninstalled`);
+      toast.add({ title: `Release "${name}" uninstalled`, type: "success" });
       setSelected(undefined);
       refresh();
     } catch (cause) {
@@ -120,11 +118,10 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
     const ns = selected?.namespace || namespace;
     if (!contextId || !ns || busy) return;
     setBusy(true);
-    setMessage("");
     setDetailError("");
     try {
       await desktop.helm.rollback({ contextId, namespace: ns, name, revision });
-      setMessage(`Release "${name}" rolled back${revision ? ` to revision ${revision}` : " to the previous revision"}`);
+      toast.add({ title: `Release "${name}" rolled back${revision ? ` to revision ${revision}` : " to the previous revision"}`, type: "success" });
       refresh();
     } catch (cause) {
       setDetailError(cause instanceof Error ? cause.message : String(cause));
@@ -133,21 +130,23 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
     }
   }, [contextId, namespace, selected, busy, refresh]);
 
-  const upgrade = useCallback(async (input: HelmUpgradeInput): Promise<boolean> => {
+  const upgrade = useCallback(async (input: HelmUpgradeInput): Promise<string | null> => {
     const ns = selected?.namespace || namespace;
-    if (!contextId || !ns || busy) return false;
+    if (!contextId || !ns || busy) return "Another operation is already in progress";
     setBusy(true);
-    setMessage("");
     setDetailError("");
     try {
       const response = await desktop.helm.upgrade({ contextId, namespace: ns, ...input });
-      setMessage(`Release "${input.name}" upgraded to revision ${response.revision}`);
+      toast.add({ title: `Release "${input.name}" upgraded to revision ${response.revision}`, type: "success" });
       await select(input.name, ns);
       refresh();
-      return true;
+      return null;
     } catch (cause) {
-      setDetailError(cause instanceof Error ? cause.message : String(cause));
-      return false;
+      // Returned so the open dialog can show it; detailError keeps it visible
+      // on the detail view after the dialog closes.
+      const failure = cause instanceof Error ? cause.message : String(cause);
+      setDetailError(failure);
+      return failure;
     } finally {
       setBusy(false);
     }
@@ -161,7 +160,6 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
     detailLoading,
     detailError,
     busy,
-    message,
     generation,
     refresh,
     select,

--- a/apps/desktop/src/renderer/hooks/useHelm.ts
+++ b/apps/desktop/src/renderer/hooks/useHelm.ts
@@ -22,7 +22,7 @@ export interface HelmState {
   /** Bumps on every explicit refresh so the list effect re-fetches. */
   generation: number;
   refresh(): void;
-  select(name: string): Promise<void>;
+  select(name: string, namespace?: string): Promise<void>;
   clear(): void;
   uninstall(name: string): Promise<void>;
   rollback(name: string, revision?: number): Promise<void>;
@@ -49,7 +49,7 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
   const request = useRef(0);
 
   useEffect(() => {
-    if (!contextId || !coreReady || !namespace) return;
+    if (!contextId || !coreReady) return;
     const current = ++request.current;
     setLoading(true);
     setError("");
@@ -70,12 +70,13 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
 
   const refresh = useCallback(() => setGeneration((value) => value + 1), []);
 
-  const select = useCallback(async (name: string) => {
-    if (!contextId || !namespace || !name) return;
+  const select = useCallback(async (name: string, releaseNamespace?: string) => {
+    const ns = releaseNamespace || namespace;
+    if (!contextId || !ns || !name) return;
     setDetailLoading(true);
     setDetailError("");
     try {
-      const detail = await desktop.helm.get({ contextId, namespace, name });
+      const detail = await desktop.helm.get({ contextId, namespace: ns, name });
       setSelected(detail);
     } catch (cause) {
       setDetailError(cause instanceof Error ? cause.message : String(cause));
@@ -90,12 +91,13 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
   }, []);
 
   const uninstall = useCallback(async (name: string) => {
-    if (!contextId || !namespace || busy) return;
+    const ns = selected?.namespace || namespace;
+    if (!contextId || !ns || busy) return;
     setBusy(true);
     setMessage("");
     setDetailError("");
     try {
-      await desktop.helm.uninstall({ contextId, namespace, name });
+      await desktop.helm.uninstall({ contextId, namespace: ns, name });
       setMessage(`Release "${name}" uninstalled`);
       setSelected(undefined);
       refresh();
@@ -104,15 +106,16 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
     } finally {
       setBusy(false);
     }
-  }, [contextId, namespace, busy, refresh]);
+  }, [contextId, namespace, selected, busy, refresh]);
 
   const rollback = useCallback(async (name: string, revision?: number) => {
-    if (!contextId || !namespace || busy) return;
+    const ns = selected?.namespace || namespace;
+    if (!contextId || !ns || busy) return;
     setBusy(true);
     setMessage("");
     setDetailError("");
     try {
-      await desktop.helm.rollback({ contextId, namespace, name, revision });
+      await desktop.helm.rollback({ contextId, namespace: ns, name, revision });
       setMessage(`Release "${name}" rolled back${revision ? ` to revision ${revision}` : " to the previous revision"}`);
       refresh();
     } catch (cause) {
@@ -120,17 +123,18 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
     } finally {
       setBusy(false);
     }
-  }, [contextId, namespace, busy, refresh]);
+  }, [contextId, namespace, selected, busy, refresh]);
 
   const upgrade = useCallback(async (input: HelmUpgradeInput): Promise<boolean> => {
-    if (!contextId || !namespace || busy) return false;
+    const ns = selected?.namespace || namespace;
+    if (!contextId || !ns || busy) return false;
     setBusy(true);
     setMessage("");
     setDetailError("");
     try {
-      const response = await desktop.helm.upgrade({ contextId, namespace, ...input });
+      const response = await desktop.helm.upgrade({ contextId, namespace: ns, ...input });
       setMessage(`Release "${input.name}" upgraded to revision ${response.revision}`);
-      await select(input.name);
+      await select(input.name, ns);
       refresh();
       return true;
     } catch (cause) {
@@ -139,7 +143,7 @@ export function useHelm({ contextId, namespace, coreReady }: UseHelmOptions): He
     } finally {
       setBusy(false);
     }
-  }, [contextId, namespace, busy, select, refresh]);
+  }, [contextId, namespace, selected, busy, select, refresh]);
 
   return {
     releases,

--- a/apps/desktop/src/renderer/lib/desktop-tauri.ts
+++ b/apps/desktop/src/renderer/lib/desktop-tauri.ts
@@ -11,6 +11,8 @@ import type {
   HelmReleaseSummary,
   HelmRollbackRequest,
   HelmUninstallRequest,
+  HelmUpgradeRequest,
+  HelmUpgradeResponse,
   LogStreamBatch,
   NamespaceInfo,
   Overview,
@@ -161,6 +163,9 @@ export function createTauriDesktopApi(): DesktopApi {
       },
       rollback: async (request: HelmRollbackRequest): Promise<void> => {
         await invoke("helm_releases_rollback", { request });
+      },
+      upgrade: async (request: HelmUpgradeRequest): Promise<HelmUpgradeResponse> => {
+        return invoke<HelmUpgradeResponse>("helm_releases_upgrade", { request });
       },
     },
     resources: {

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { Toaster } from "@/components/ui/toast";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import App from "./App";
 import { applyStoredTheme } from "./hooks/useTheme";
@@ -13,7 +14,9 @@ applyStoredTheme();
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <TooltipProvider delay={500} timeout={250}>
-      <App />
+      <Toaster>
+        <App />
+      </Toaster>
     </TooltipProvider>
   </StrictMode>,
 );

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -4184,14 +4184,6 @@ button.overview-card:focus-visible {
   font-family: inherit;
 }
 
-.helm-message {
-  padding: 7px 16px;
-  border-bottom: 1px solid var(--border);
-  color: var(--healthy);
-  background: color-mix(in srgb, var(--healthy) 8%, var(--surface));
-  font-size: 11px;
-}
-
 .load-more.helm-danger {
   color: var(--failed);
 }
@@ -4348,6 +4340,24 @@ button.overview-card:focus-visible {
 .helm-upgrade-values-editor {
   min-height: 320px;
   max-height: 45vh;
+}
+
+.helm-upgrade-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--failed) 35%, transparent);
+  border-radius: 8px;
+  color: var(--failed);
+  font-size: 12px;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.helm-upgrade-error svg {
+  flex-shrink: 0;
+  margin-top: 2px;
 }
 
 /* ---- Log viewer (xterm surface) ---- */

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -2482,6 +2482,9 @@ h2 {
 .resource-yaml-editor {
   min-height: 420px;
   resize: vertical;
+  /* Match the read-only viewer: no soft wrap, long lines scroll horizontally.
+     wrap="off" on the element does the same in WebKit; this pins it across engines. */
+  white-space: pre;
 }
 
 .resource-editor-actions {

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -4198,61 +4198,28 @@ button.overview-card:focus-visible {
   background: color-mix(in srgb, var(--failed) 10%, var(--surface));
 }
 
+/* The header and release actions stay put; the tab body scrolls beneath via
+   .resource-detail-scroll, same as the resource detail layout. */
 .helm-detail {
+  display: flex;
   min-height: 0;
   flex: 1;
-  overflow: auto;
-  overscroll-behavior: contain;
-}
-
-.helm-meta-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 10px 16px;
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--border);
-}
-
-.helm-meta {
-  min-width: 0;
-}
-
-.helm-meta-label {
-  display: block;
-  margin-bottom: 2px;
-  color: var(--text-secondary);
-  font-size: 10px;
-  font-weight: 600;
-}
-
-.helm-meta-value {
-  display: block;
-  overflow: hidden;
-  color: var(--text);
-  font-size: 12px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  flex-direction: column;
 }
 
 .helm-revisions {
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--border);
-}
-
-.helm-revisions h2,
-.helm-code-heading h2 {
-  margin: 0 0 8px;
-  color: var(--text);
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.helm-revisions ul {
   display: grid;
   gap: 6px;
   margin: 0;
   padding: 0;
   list-style: none;
+}
+
+.helm-code-heading h2 {
+  margin: 0 0 8px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .helm-revisions li {
@@ -4271,7 +4238,6 @@ button.overview-card:focus-visible {
 
 .helm-code {
   padding: 14px 16px;
-  border-bottom: 1px solid var(--border);
 }
 
 .helm-code-heading {
@@ -4286,8 +4252,9 @@ button.overview-card:focus-visible {
   font-weight: 600;
 }
 
+/* The tab scroll region owns vertical overflow; capping the code block would
+   nest a second scrollbar inside it. */
 .helm-code-body {
-  max-height: 320px;
   margin: 0;
   padding: 10px 12px;
   overflow: auto;
@@ -4343,6 +4310,41 @@ button.overview-card:focus-visible {
 
 .helm-upgrade-input:focus {
   border-color: var(--focus);
+}
+
+/* Kite-style split: chart defaults sit read-only beside the editable values,
+   so parameters that only exist as defaults (replicas, probes…) are visible
+   while editing. Both panes share one height and scroll independently. */
+.helm-upgrade-dialog {
+  width: min(1040px, calc(100vw - 40px));
+  max-width: 1040px;
+}
+
+.helm-upgrade-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 10px;
+}
+
+.helm-upgrade-defaults {
+  min-height: 320px;
+  max-height: 45vh;
+  margin: 0;
+  padding: 10px 12px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  background: var(--surface-muted);
+  font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.helm-upgrade-values-editor {
+  min-height: 320px;
+  max-height: 45vh;
 }
 
 /* ---- Log viewer (xterm surface) ---- */

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -4309,6 +4309,42 @@ button.overview-card:focus-visible {
   font-size: 11px;
 }
 
+.helm-upgrade-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.helm-upgrade-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.helm-upgrade-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.helm-upgrade-input {
+  height: 28px;
+  min-width: 0;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  outline: none;
+  background: var(--surface-muted);
+  color: var(--text);
+  font-size: 12px;
+}
+
+.helm-upgrade-input:focus {
+  border-color: var(--focus);
+}
+
 /* ---- Log viewer (xterm surface) ---- */
 
 .log-viewer {

--- a/apps/desktop/src/renderer/views/HelmUpgradeDialog.tsx
+++ b/apps/desktop/src/renderer/views/HelmUpgradeDialog.tsx
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+import { CircleArrowUp } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { HelmReleaseDetail } from "../../shared/types";
+import type { HelmUpgradeInput } from "../hooks/useHelm";
+
+export interface HelmUpgradeDialogProps {
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  detail: HelmReleaseDetail;
+  busy: boolean;
+  onUpgrade(input: HelmUpgradeInput): Promise<boolean>;
+}
+
+/**
+ * Upgrade form for an installed release. The repo URL cannot be defaulted
+ * because releases do not record their origin repository, so the user always
+ * confirms it. Values are prefilled with the release's current values and
+ * replace them wholesale; clearing the field resets to chart defaults.
+ */
+export function HelmUpgradeDialog({ open, onOpenChange, detail, busy, onUpgrade }: HelmUpgradeDialogProps) {
+  const [repoUrl, setRepoUrl] = useState("");
+  const [chart, setChart] = useState(detail.chart);
+  const [version, setVersion] = useState(detail.chartVersion);
+  const [values, setValues] = useState(detail.values ?? "");
+
+  useEffect(() => {
+    if (!open) return;
+    setRepoUrl("");
+    setChart(detail.chart);
+    setVersion(detail.chartVersion);
+    setValues(detail.values ?? "");
+  }, [open, detail]);
+
+  const submit = async () => {
+    const ok = await onUpgrade({
+      name: detail.name,
+      repoUrl: repoUrl.trim(),
+      chart: chart.trim(),
+      version: version.trim() || undefined,
+      values,
+    });
+    if (ok) onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="create-resource-dialog" data-testid="helm-upgrade-dialog">
+        <DialogHeader>
+          <DialogTitle>Upgrade {detail.name}</DialogTitle>
+          <DialogDescription>
+            Values below replace the release&apos;s current values entirely. Clear them to reset to the chart defaults.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="helm-upgrade-fields">
+          <label className="helm-upgrade-field">
+            <span>Repository URL</span>
+            <input
+              className="helm-upgrade-input"
+              data-testid="helm-upgrade-repo-url"
+              disabled={busy}
+              onChange={(event) => setRepoUrl(event.target.value)}
+              placeholder="https://charts.bitnami.com/bitnami"
+              spellCheck={false}
+              value={repoUrl}
+            />
+          </label>
+          <div className="helm-upgrade-row">
+            <label className="helm-upgrade-field">
+              <span>Chart</span>
+              <input
+                className="helm-upgrade-input"
+                data-testid="helm-upgrade-chart"
+                disabled={busy}
+                onChange={(event) => setChart(event.target.value)}
+                spellCheck={false}
+                value={chart}
+              />
+            </label>
+            <label className="helm-upgrade-field">
+              <span>Chart version</span>
+              <input
+                className="helm-upgrade-input"
+                data-testid="helm-upgrade-version"
+                disabled={busy}
+                onChange={(event) => setVersion(event.target.value)}
+                placeholder="latest"
+                spellCheck={false}
+                value={version}
+              />
+            </label>
+          </div>
+          <textarea
+            aria-label="Upgrade values YAML"
+            className="resource-yaml-editor create-resource-editor"
+            data-testid="helm-upgrade-values"
+            onChange={(event) => setValues(event.target.value)}
+            readOnly={busy}
+            spellCheck={false}
+            value={values}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" disabled={busy} onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            data-testid="helm-upgrade-submit"
+            disabled={busy || !repoUrl.trim() || !chart.trim()}
+            onClick={() => void submit()}
+          >
+            <CircleArrowUp data-icon="inline-start" />
+            Upgrade release
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/renderer/views/HelmUpgradeDialog.tsx
+++ b/apps/desktop/src/renderer/views/HelmUpgradeDialog.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { CircleArrowUp } from "lucide-react";
+import { CircleArrowUp, LoaderCircle, TriangleAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -20,7 +20,7 @@ export interface HelmUpgradeDialogProps {
   onOpenChange(open: boolean): void;
   detail: HelmReleaseDetail;
   busy: boolean;
-  onUpgrade(input: HelmUpgradeInput): Promise<boolean>;
+  onUpgrade(input: HelmUpgradeInput): Promise<string | null>;
 }
 
 /**
@@ -33,7 +33,9 @@ export interface HelmUpgradeDialogProps {
  * Submission is a two-step review, mirroring the resource mutation flow:
  * edit the values, review the diff against the release's current values,
  * then confirm. Values replace the release's current values wholesale;
- * clearing the field resets to the chart defaults.
+ * clearing the field resets to the chart defaults. While the upgrade runs
+ * the dialog cannot be dismissed; a failure is shown in place so the user
+ * can adjust and retry.
  */
 export function HelmUpgradeDialog({ open, onOpenChange, detail, busy, onUpgrade }: HelmUpgradeDialogProps) {
   const [repoUrl, setRepoUrl] = useState("");
@@ -41,6 +43,7 @@ export function HelmUpgradeDialog({ open, onOpenChange, detail, busy, onUpgrade 
   const [version, setVersion] = useState(detail.chartVersion);
   const [values, setValues] = useState(detail.values ?? "");
   const [reviewing, setReviewing] = useState(false);
+  const [error, setError] = useState("");
 
   useEffect(() => {
     if (!open) return;
@@ -49,23 +52,36 @@ export function HelmUpgradeDialog({ open, onOpenChange, detail, busy, onUpgrade 
     setVersion(detail.chartVersion);
     setValues(detail.values ?? "");
     setReviewing(false);
+    setError("");
   }, [open, detail]);
 
   const reuseChart = !repoUrl.trim();
 
   const submit = async () => {
-    const ok = await onUpgrade({
+    setError("");
+    const failure = await onUpgrade({
       name: detail.name,
       repoUrl: repoUrl.trim(),
       chart: chart.trim(),
       version: version.trim() || undefined,
       values,
     });
-    if (ok) onOpenChange(false);
+    if (failure) {
+      setError(failure);
+      return;
+    }
+    onOpenChange(false);
+  };
+
+  // An upgrade in flight must not be dismissed: the request keeps running
+  // server-side, so closing would only hide its outcome.
+  const handleOpenChange = (next: boolean) => {
+    if (busy) return;
+    onOpenChange(next);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="helm-upgrade-dialog" data-testid="helm-upgrade-dialog">
         <DialogHeader>
           <DialogTitle>Upgrade {detail.name}</DialogTitle>
@@ -84,7 +100,7 @@ export function HelmUpgradeDialog({ open, onOpenChange, detail, busy, onUpgrade 
                 : `Pulls chart ${chart.trim()} ${version.trim() || "(latest)"} from ${repoUrl.trim()} and replaces the values.`}
             </div>
             <MutationDiffView
-              name={`${detail.name}-values.yaml`}
+              name={`${detail.name}-values`}
               beforeYaml={detail.values ?? ""}
               afterYaml={values}
               className="mutation-review-diff"
@@ -154,6 +170,13 @@ export function HelmUpgradeDialog({ open, onOpenChange, detail, busy, onUpgrade 
           </div>
         )}
 
+        {error ? (
+          <div className="helm-upgrade-error" data-testid="helm-upgrade-error" role="alert">
+            <TriangleAlert aria-hidden="true" className="size-4" />
+            <span>{error}</span>
+          </div>
+        ) : null}
+
         <DialogFooter>
           {reviewing ? (
             <>
@@ -165,8 +188,12 @@ export function HelmUpgradeDialog({ open, onOpenChange, detail, busy, onUpgrade 
                 disabled={busy}
                 onClick={() => void submit()}
               >
-                <CircleArrowUp data-icon="inline-start" />
-                Confirm upgrade
+                {busy ? (
+                  <LoaderCircle aria-hidden="true" className="spin size-3.5" />
+                ) : (
+                  <CircleArrowUp data-icon="inline-start" />
+                )}
+                {busy ? "Upgrading…" : "Confirm upgrade"}
               </Button>
             </>
           ) : (

--- a/apps/desktop/src/renderer/views/HelmUpgradeDialog.tsx
+++ b/apps/desktop/src/renderer/views/HelmUpgradeDialog.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { HelmReleaseDetail } from "../../shared/types";
+import { MutationDiffView } from "../detail/MutationDiffView";
 import type { HelmUpgradeInput } from "../hooks/useHelm";
 
 export interface HelmUpgradeDialogProps {
@@ -23,16 +24,23 @@ export interface HelmUpgradeDialogProps {
 }
 
 /**
- * Upgrade form for an installed release. The repo URL cannot be defaulted
- * because releases do not record their origin repository, so the user always
- * confirms it. Values are prefilled with the release's current values and
- * replace them wholesale; clearing the field resets to chart defaults.
+ * Upgrade form for an installed release. The repo URL stays empty for the
+ * common values-only upgrade: the release stores its chart's full contents,
+ * so the core reuses that chart instead of re-pulling one (releases never
+ * record their origin repository). Filling a repo URL switches to pulling
+ * the named chart (and optional version) from that repository.
+ *
+ * Submission is a two-step review, mirroring the resource mutation flow:
+ * edit the values, review the diff against the release's current values,
+ * then confirm. Values replace the release's current values wholesale;
+ * clearing the field resets to the chart defaults.
  */
 export function HelmUpgradeDialog({ open, onOpenChange, detail, busy, onUpgrade }: HelmUpgradeDialogProps) {
   const [repoUrl, setRepoUrl] = useState("");
   const [chart, setChart] = useState(detail.chart);
   const [version, setVersion] = useState(detail.chartVersion);
   const [values, setValues] = useState(detail.values ?? "");
+  const [reviewing, setReviewing] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -40,7 +48,10 @@ export function HelmUpgradeDialog({ open, onOpenChange, detail, busy, onUpgrade 
     setChart(detail.chart);
     setVersion(detail.chartVersion);
     setValues(detail.values ?? "");
+    setReviewing(false);
   }, [open, detail]);
+
+  const reuseChart = !repoUrl.trim();
 
   const submit = async () => {
     const ok = await onUpgrade({
@@ -55,75 +66,124 @@ export function HelmUpgradeDialog({ open, onOpenChange, detail, busy, onUpgrade 
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="create-resource-dialog" data-testid="helm-upgrade-dialog">
+      <DialogContent className="helm-upgrade-dialog" data-testid="helm-upgrade-dialog">
         <DialogHeader>
           <DialogTitle>Upgrade {detail.name}</DialogTitle>
           <DialogDescription>
-            Values below replace the release&apos;s current values entirely. Clear them to reset to the chart defaults.
+            {reviewing
+              ? "Review the values diff before applying. Confirming creates a new revision."
+              : "Values below replace the release's current values entirely. Clear them to reset to the chart defaults."}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="helm-upgrade-fields">
-          <label className="helm-upgrade-field">
-            <span>Repository URL</span>
-            <input
-              className="helm-upgrade-input"
-              data-testid="helm-upgrade-repo-url"
-              disabled={busy}
-              onChange={(event) => setRepoUrl(event.target.value)}
-              placeholder="https://charts.bitnami.com/bitnami"
-              spellCheck={false}
-              value={repoUrl}
+        {reviewing ? (
+          <>
+            <div className="mutation-review-status" data-testid="helm-upgrade-summary">
+              {reuseChart
+                ? `Reuses the installed chart ${detail.chart} ${detail.chartVersion} — only the values change.`
+                : `Pulls chart ${chart.trim()} ${version.trim() || "(latest)"} from ${repoUrl.trim()} and replaces the values.`}
+            </div>
+            <MutationDiffView
+              name={`${detail.name}-values.yaml`}
+              beforeYaml={detail.values ?? ""}
+              afterYaml={values}
+              className="mutation-review-diff"
+              testId="helm-upgrade-diff"
+              ariaLabel="Values diff"
             />
-          </label>
-          <div className="helm-upgrade-row">
+          </>
+        ) : (
+          <div className="helm-upgrade-fields">
             <label className="helm-upgrade-field">
-              <span>Chart</span>
+              <span>Repository URL (optional — leave empty to reuse the installed chart)</span>
               <input
                 className="helm-upgrade-input"
-                data-testid="helm-upgrade-chart"
+                data-testid="helm-upgrade-repo-url"
                 disabled={busy}
-                onChange={(event) => setChart(event.target.value)}
+                onChange={(event) => setRepoUrl(event.target.value)}
+                placeholder="https://charts.bitnami.com/bitnami"
                 spellCheck={false}
-                value={chart}
+                value={repoUrl}
               />
             </label>
-            <label className="helm-upgrade-field">
-              <span>Chart version</span>
-              <input
-                className="helm-upgrade-input"
-                data-testid="helm-upgrade-version"
-                disabled={busy}
-                onChange={(event) => setVersion(event.target.value)}
-                placeholder="latest"
-                spellCheck={false}
-                value={version}
-              />
-            </label>
+            <div className="helm-upgrade-row">
+              <label className="helm-upgrade-field">
+                <span>Chart</span>
+                <input
+                  className="helm-upgrade-input"
+                  data-testid="helm-upgrade-chart"
+                  disabled={busy || reuseChart}
+                  onChange={(event) => setChart(event.target.value)}
+                  spellCheck={false}
+                  value={chart}
+                />
+              </label>
+              <label className="helm-upgrade-field">
+                <span>Chart version</span>
+                <input
+                  className="helm-upgrade-input"
+                  data-testid="helm-upgrade-version"
+                  disabled={busy || reuseChart}
+                  onChange={(event) => setVersion(event.target.value)}
+                  placeholder="latest"
+                  spellCheck={false}
+                  value={version}
+                />
+              </label>
+            </div>
+            <div className="helm-upgrade-columns">
+              <div className="helm-upgrade-field">
+                <span>Chart defaults (read-only)</span>
+                <pre className="helm-upgrade-defaults" data-testid="helm-upgrade-defaults">
+                  {detail.chartValues || "This chart ships no default values."}
+                </pre>
+              </div>
+              <div className="helm-upgrade-field">
+                <span>Your values</span>
+                <textarea
+                  aria-label="Upgrade values YAML"
+                  className="resource-yaml-editor helm-upgrade-values-editor"
+                  data-testid="helm-upgrade-values"
+                  onChange={(event) => setValues(event.target.value)}
+                  readOnly={busy}
+                  spellCheck={false}
+                  value={values}
+                />
+              </div>
+            </div>
           </div>
-          <textarea
-            aria-label="Upgrade values YAML"
-            className="resource-yaml-editor create-resource-editor"
-            data-testid="helm-upgrade-values"
-            onChange={(event) => setValues(event.target.value)}
-            readOnly={busy}
-            spellCheck={false}
-            value={values}
-          />
-        </div>
+        )}
 
         <DialogFooter>
-          <Button variant="outline" disabled={busy} onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button
-            data-testid="helm-upgrade-submit"
-            disabled={busy || !repoUrl.trim() || !chart.trim()}
-            onClick={() => void submit()}
-          >
-            <CircleArrowUp data-icon="inline-start" />
-            Upgrade release
-          </Button>
+          {reviewing ? (
+            <>
+              <Button variant="outline" disabled={busy} onClick={() => setReviewing(false)}>
+                Back to edit
+              </Button>
+              <Button
+                data-testid="helm-upgrade-submit"
+                disabled={busy}
+                onClick={() => void submit()}
+              >
+                <CircleArrowUp data-icon="inline-start" />
+                Confirm upgrade
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" disabled={busy} onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                data-testid="helm-upgrade-review"
+                disabled={busy || (!reuseChart && !chart.trim())}
+                onClick={() => setReviewing(true)}
+              >
+                <CircleArrowUp data-icon="inline-start" />
+                Review changes
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/desktop/src/renderer/views/HelmView.tsx
+++ b/apps/desktop/src/renderer/views/HelmView.tsx
@@ -18,7 +18,7 @@ export interface HelmViewProps {
   busy: boolean;
   message: string;
   onRefresh(): void;
-  onSelect(name: string): void;
+  onSelect(name: string, namespace: string): void;
   onBack(): void;
   onUninstall(name: string): void;
   onRollback(name: string, revision?: number): void;
@@ -114,7 +114,7 @@ function ReleaseTable({
   loading: boolean;
   error: string;
   namespace: string;
-  onSelect(name: string): void;
+  onSelect(name: string, namespace: string): void;
 }) {
   if (loading) {
     return (
@@ -157,7 +157,7 @@ function ReleaseTable({
             className="table-row helm-grid"
             data-testid={`helm-release-${release.name}`}
             key={release.name}
-            onClick={() => onSelect(release.name)}
+            onClick={() => onSelect(release.name, release.namespace)}
             type="button"
           >
             <span className="primary-cell">{release.name}</span>

--- a/apps/desktop/src/renderer/views/HelmView.tsx
+++ b/apps/desktop/src/renderer/views/HelmView.tsx
@@ -16,12 +16,11 @@ export interface HelmViewProps {
   detailLoading: boolean;
   detailError: string;
   busy: boolean;
-  message: string;
   onRefresh(): void;
   onSelect(name: string, namespace: string): void;
   onUninstall(name: string): void;
   onRollback(name: string, revision?: number): void;
-  onUpgrade(input: HelmUpgradeInput): Promise<boolean>;
+  onUpgrade(input: HelmUpgradeInput): Promise<string | null>;
 }
 
 const STATUS_TONE: Record<string, string> = {
@@ -49,7 +48,6 @@ export function HelmView({
   detailLoading,
   detailError,
   busy,
-  message,
   onRefresh,
   onSelect,
   onUninstall,
@@ -72,12 +70,6 @@ export function HelmView({
           </div>
         </div>
       )}
-
-      {message ? (
-        <div className="helm-message" data-testid="helm-message" role="status">
-          {message}
-        </div>
-      ) : null}
 
       {selected ? (
         <ReleaseDetail
@@ -191,7 +183,7 @@ function ReleaseDetail({
   busy: boolean;
   onUninstall(name: string): void;
   onRollback(name: string, revision?: number): void;
-  onUpgrade(input: HelmUpgradeInput): Promise<boolean>;
+  onUpgrade(input: HelmUpgradeInput): Promise<string | null>;
 }) {
   const [upgradeOpen, setUpgradeOpen] = useState(false);
   const [tab, setTab] = useState<HelmDetailTab>("overview");

--- a/apps/desktop/src/renderer/views/HelmView.tsx
+++ b/apps/desktop/src/renderer/views/HelmView.tsx
@@ -1,6 +1,6 @@
-import { ArrowLeft, CircleArrowUp, LoaderCircle, RotateCcw, Trash2, TriangleAlert } from "lucide-react";
+import { CircleArrowUp, LoaderCircle, RotateCcw, Trash2, TriangleAlert } from "lucide-react";
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/ui/tabs";
 import type { HelmReleaseDetail, HelmReleaseSummary } from "../../shared/types";
 import type { HelmUpgradeInput } from "../hooks/useHelm";
 import { formatAge } from "../lib/format";
@@ -19,7 +19,6 @@ export interface HelmViewProps {
   message: string;
   onRefresh(): void;
   onSelect(name: string, namespace: string): void;
-  onBack(): void;
   onUninstall(name: string): void;
   onRollback(name: string, revision?: number): void;
   onUpgrade(input: HelmUpgradeInput): Promise<boolean>;
@@ -53,25 +52,26 @@ export function HelmView({
   message,
   onRefresh,
   onSelect,
-  onBack,
   onUninstall,
   onRollback,
   onUpgrade,
 }: HelmViewProps) {
   return (
     <section aria-label="Helm releases" className="helm-pane" data-testid="helm-view">
-      <div className="pane-heading">
-        <div>
-          <h1>Releases</h1>
-          <p>Helm · {contextName ? `${contextName} · ` : ""}{namespace}</p>
+      {selected ? null : (
+        <div className="pane-heading">
+          <div>
+            <h1>Releases</h1>
+            <p>Helm · {contextName ? `${contextName} · ` : ""}{namespace}</p>
+          </div>
+          <div className="resource-summary">
+            <span>{releases.length} loaded</span>
+            <button className="load-more" data-testid="helm-refresh" disabled={loading || busy} onClick={onRefresh} type="button">
+              Refresh
+            </button>
+          </div>
         </div>
-        <div className="resource-summary">
-          <span>{releases.length} loaded</span>
-          <button className="load-more" data-testid="helm-refresh" disabled={loading || busy} onClick={onRefresh} type="button">
-            Refresh
-          </button>
-        </div>
-      </div>
+      )}
 
       {message ? (
         <div className="helm-message" data-testid="helm-message" role="status">
@@ -81,11 +81,11 @@ export function HelmView({
 
       {selected ? (
         <ReleaseDetail
+          key={`${selected.namespace}/${selected.name}`}
           detail={selected}
           detailLoading={detailLoading}
           detailError={detailError}
           busy={busy}
-          onBack={onBack}
           onUninstall={onUninstall}
           onRollback={onRollback}
           onUpgrade={onUpgrade}
@@ -174,12 +174,13 @@ function ReleaseTable({
   );
 }
 
+type HelmDetailTab = "overview" | "values" | "manifest";
+
 function ReleaseDetail({
   detail,
   detailLoading,
   detailError,
   busy,
-  onBack,
   onUninstall,
   onRollback,
   onUpgrade,
@@ -188,24 +189,15 @@ function ReleaseDetail({
   detailLoading: boolean;
   detailError: string;
   busy: boolean;
-  onBack(): void;
   onUninstall(name: string): void;
   onRollback(name: string, revision?: number): void;
   onUpgrade(input: HelmUpgradeInput): Promise<boolean>;
 }) {
   const [upgradeOpen, setUpgradeOpen] = useState(false);
+  const [tab, setTab] = useState<HelmDetailTab>("overview");
   return (
     <div className="helm-detail" data-testid="helm-detail">
       <header className="resource-detail-header">
-        <Button
-          aria-label="Back to releases"
-          data-testid="helm-back"
-          onClick={onBack}
-          size="icon"
-          variant="ghost"
-        >
-          <ArrowLeft />
-        </Button>
         <div className="resource-detail-identity">
           <span className="resource-detail-breadcrumb">
             Helm · {detail.namespace} · {detail.chart} {detail.chartVersion}
@@ -260,13 +252,29 @@ function ReleaseDetail({
           <span>Loading release…</span>
         </div>
       ) : (
-        <>
-          <ReleaseMeta detail={detail} />
-          <RevisionHistory history={detail.history} />
-          <CodeBlock title="Values" body={detail.values} placeholder="No custom values" dataTestid="helm-values" />
-          <CodeBlock title="Manifest" body={detail.manifest} placeholder="No manifest" dataTestid="helm-manifest" truncated={detail.truncated} />
-          <CodeBlock title="Notes" body={detail.notes} placeholder="No notes" dataTestid="helm-notes" />
-        </>
+        <Tabs
+          className="resource-detail-tabs"
+          value={tab}
+          onValueChange={(value) => setTab(value as HelmDetailTab)}
+        >
+          <TabsList className="resource-detail-tab-list" aria-label="Release details">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="values">Values</TabsTrigger>
+            <TabsTrigger value="manifest">Manifest</TabsTrigger>
+          </TabsList>
+
+          <div className="resource-detail-scroll">
+            <TabsContent value="overview">
+              <ReleaseOverview detail={detail} />
+            </TabsContent>
+            <TabsContent value="values">
+              <CodeBlock title="Values" body={detail.values} placeholder="No custom values" dataTestid="helm-values" />
+            </TabsContent>
+            <TabsContent value="manifest">
+              <CodeBlock title="Manifest" body={detail.manifest} placeholder="No manifest" dataTestid="helm-manifest" truncated={detail.truncated} />
+            </TabsContent>
+          </div>
+        </Tabs>
       )}
       <HelmUpgradeDialog
         open={upgradeOpen}
@@ -279,24 +287,60 @@ function ReleaseDetail({
   );
 }
 
-function ReleaseMeta({ detail }: { detail: HelmReleaseDetail }) {
+/** Overview speaks the resource detail's card language: a vitals strip of
+ * headline facts, then bordered cards for information, history, and notes. */
+function ReleaseOverview({ detail }: { detail: HelmReleaseDetail }) {
   return (
-    <div className="helm-meta-grid" data-testid="helm-meta">
-      <Meta label="Status" value={detail.status} />
-      <Meta label="Revision" value={String(detail.version)} />
-      <Meta label="Chart" value={`${detail.chart} ${detail.chartVersion}`} />
-      <Meta label="App version" value={detail.appVersion || "—"} />
-      <Meta label="Updated" value={detail.updatedAt ? formatAge(detail.updatedAt) : "—"} />
-      {detail.description ? <Meta label="Description" value={detail.description} /> : null}
+    <div className="resource-overview" data-aside="off" data-testid="helm-overview">
+      <dl className="resource-vitals" data-testid="helm-vitals">
+        <div>
+          <dd>
+            <span className={`status-dot ${statusTone(detail.status)}`} aria-hidden="true" />
+            {detail.status}
+          </dd>
+          <dt>Status</dt>
+        </div>
+        <div><dd>{detail.version}</dd><dt>Revision</dt></div>
+        <div><dd>{detail.chartVersion}</dd><dt>Chart version</dt></div>
+        <div><dd>{detail.appVersion || "—"}</dd><dt>App version</dt></div>
+        <div><dd>{detail.updatedAt ? formatAge(detail.updatedAt) : "—"}</dd><dt>Updated</dt></div>
+      </dl>
+
+      <div className="resource-overview-body">
+        <div className="resource-overview-main">
+          <section className="resource-detail-section">
+            <div className="resource-section-heading">
+              <h2>Release information</h2>
+            </div>
+            <dl className="resource-definition-list" data-testid="helm-meta">
+              <Definition label="Chart" value={detail.chart} />
+              <Definition label="Namespace" value={detail.namespace} />
+              <Definition label="Updated" value={detail.updatedAt ? formatAge(detail.updatedAt) : "—"} />
+              {detail.description ? <Definition label="Description" value={detail.description} /> : null}
+            </dl>
+          </section>
+
+          <RevisionHistory history={detail.history} />
+
+          {detail.notes ? (
+            <section className="resource-detail-section" data-testid="helm-notes">
+              <div className="resource-section-heading">
+                <h2>Notes</h2>
+              </div>
+              <pre className="helm-code-body">{detail.notes}</pre>
+            </section>
+          ) : null}
+        </div>
+      </div>
     </div>
   );
 }
 
-function Meta({ label, value }: { label: string; value: string }) {
+function Definition({ label, value }: { label: string; value: string }) {
   return (
-    <div className="helm-meta">
-      <span className="helm-meta-label">{label}</span>
-      <span className="helm-meta-value">{value}</span>
+    <div>
+      <dt>{label}</dt>
+      <dd>{value}</dd>
     </div>
   );
 }
@@ -304,12 +348,17 @@ function Meta({ label, value }: { label: string; value: string }) {
 function RevisionHistory({ history }: { history: HelmReleaseSummary[] }) {
   const revisions = [...history].sort((a, b) => b.version - a.version);
   return (
-    <div className="helm-revisions" data-testid="helm-history">
-      <h2>Revision history</h2>
+    <section className="resource-detail-section">
+      <div className="resource-section-heading">
+        <h2>
+          Revision history{" "}
+          <span className="resource-section-count">{revisions.length}</span>
+        </h2>
+      </div>
       {revisions.length === 0 ? (
         <div className="helm-revisions-empty">No history</div>
       ) : (
-        <ul>
+        <ul className="helm-revisions" data-testid="helm-history">
           {revisions.map((item) => (
             <li key={item.version}>
               <span className="tabular">v{item.version}</span>
@@ -320,7 +369,7 @@ function RevisionHistory({ history }: { history: HelmReleaseSummary[] }) {
           ))}
         </ul>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/apps/desktop/src/renderer/views/HelmView.tsx
+++ b/apps/desktop/src/renderer/views/HelmView.tsx
@@ -1,7 +1,10 @@
-import { ArrowLeft, LoaderCircle, RotateCcw, Trash2, TriangleAlert } from "lucide-react";
+import { ArrowLeft, CircleArrowUp, LoaderCircle, RotateCcw, Trash2, TriangleAlert } from "lucide-react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { HelmReleaseDetail, HelmReleaseSummary } from "../../shared/types";
+import type { HelmUpgradeInput } from "../hooks/useHelm";
 import { formatAge } from "../lib/format";
+import { HelmUpgradeDialog } from "./HelmUpgradeDialog";
 
 export interface HelmViewProps {
   contextName?: string;
@@ -19,6 +22,7 @@ export interface HelmViewProps {
   onBack(): void;
   onUninstall(name: string): void;
   onRollback(name: string, revision?: number): void;
+  onUpgrade(input: HelmUpgradeInput): Promise<boolean>;
 }
 
 const STATUS_TONE: Record<string, string> = {
@@ -52,6 +56,7 @@ export function HelmView({
   onBack,
   onUninstall,
   onRollback,
+  onUpgrade,
 }: HelmViewProps) {
   return (
     <section aria-label="Helm releases" className="helm-pane" data-testid="helm-view">
@@ -83,6 +88,7 @@ export function HelmView({
           onBack={onBack}
           onUninstall={onUninstall}
           onRollback={onRollback}
+          onUpgrade={onUpgrade}
         />
       ) : (
         <ReleaseTable
@@ -176,6 +182,7 @@ function ReleaseDetail({
   onBack,
   onUninstall,
   onRollback,
+  onUpgrade,
 }: {
   detail: HelmReleaseDetail;
   detailLoading: boolean;
@@ -184,7 +191,9 @@ function ReleaseDetail({
   onBack(): void;
   onUninstall(name: string): void;
   onRollback(name: string, revision?: number): void;
+  onUpgrade(input: HelmUpgradeInput): Promise<boolean>;
 }) {
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
   return (
     <div className="helm-detail" data-testid="helm-detail">
       <header className="resource-detail-header">
@@ -207,6 +216,16 @@ function ReleaseDetail({
           </div>
         </div>
         <div className="resource-summary">
+          <button
+            className="load-more"
+            data-testid="helm-upgrade"
+            disabled={busy || detailLoading}
+            onClick={() => setUpgradeOpen(true)}
+            type="button"
+          >
+            {busy ? <LoaderCircle aria-hidden="true" className="spin size-3.5" /> : <CircleArrowUp aria-hidden="true" className="size-3.5" />}
+            Upgrade
+          </button>
           <button
             className="load-more"
             data-testid="helm-rollback"
@@ -249,6 +268,13 @@ function ReleaseDetail({
           <CodeBlock title="Notes" body={detail.notes} placeholder="No notes" dataTestid="helm-notes" />
         </>
       )}
+      <HelmUpgradeDialog
+        open={upgradeOpen}
+        onOpenChange={setUpgradeOpen}
+        detail={detail}
+        busy={busy}
+        onUpgrade={onUpgrade}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -344,6 +344,8 @@ export interface HelmReleaseDetail extends HelmReleaseSummary {
   notes?: string;
   values?: string;
   manifest?: string;
+  /** The chart's default values.yaml as stored in the release. */
+  chartValues?: string;
   /** True when the core truncated values or manifest to the size cap. */
   truncated?: boolean;
   history: HelmReleaseSummary[];

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -376,8 +376,9 @@ export interface HelmUpgradeRequest {
   namespace: string;
   name: string;
   /**
-   * Chart repository URL. Required because releases do not record their
-   * origin repository, so there is nothing to default it from.
+   * Chart repository URL. Empty reuses the chart stored in the release
+   * (values-only upgrade); set with chart to pull a fresh chart from a
+   * repository, since releases do not record their origin repository.
    */
   repoUrl: string;
   chart: string;

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -369,6 +369,28 @@ export interface HelmRollbackRequest {
   revision?: number;
 }
 
+export interface HelmUpgradeRequest {
+  contextId: string;
+  namespace: string;
+  name: string;
+  /**
+   * Chart repository URL. Required because releases do not record their
+   * origin repository, so there is nothing to default it from.
+   */
+  repoUrl: string;
+  chart: string;
+  version?: string;
+  /**
+   * Complete user values YAML for the new revision. Empty resets the
+   * release to the chart defaults (helm upgrade without --reuse-values).
+   */
+  values?: string;
+}
+
+export interface HelmUpgradeResponse {
+  revision: number;
+}
+
 export interface OverviewCount {
   total: number;
   ready: number;
@@ -491,6 +513,7 @@ export interface DesktopApi {
     get(request: HelmGetRequest): Promise<HelmReleaseDetail>;
     uninstall(request: HelmUninstallRequest): Promise<void>;
     rollback(request: HelmRollbackRequest): Promise<void>;
+    upgrade(request: HelmUpgradeRequest): Promise<HelmUpgradeResponse>;
   };
   resources: {
     list(request: ResourceListRequest): Promise<ResourceListResponse>;

--- a/apps/desktop/tests/live/live-web.spec.ts
+++ b/apps/desktop/tests/live/live-web.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Live web verification: the real renderer (Vite dev server) driven by
+ * Playwright in Chromium, backed by the real running sidecar and cluster via
+ * the shim/proxy pair in support.ts. Covers the three GUI checks that were
+ * too slow under computer-use automation:
+ *   1. namespace scope picked on one view carries over to the Helm view;
+ *   2. an open Helm release detail closes when the namespace scope switches;
+ *   3. the upgrade dialog's chart-defaults pane renders real chart values.
+ * Read-only against the cluster: no mutation endpoints are exercised.
+ */
+import { expect, test, type Page } from "@playwright/test";
+import { installLiveCore } from "./support";
+
+const CONTEXT_ID = process.env.ASTER_LIVE_CONTEXT ?? "staging-test-admin@staging-usw";
+const NAMESPACE = process.env.ASTER_LIVE_NAMESPACE ?? "brain-system-skills";
+const RELEASE = process.env.ASTER_LIVE_RELEASE ?? "brain-system-skills";
+
+async function connect(page: Page): Promise<void> {
+  await page.goto("/");
+  const option = page.getByTestId(`context-option-${CONTEXT_ID}`);
+  await expect(option).toBeVisible({ timeout: 30_000 });
+  await option.click();
+  await option.dblclick();
+  await expect(page.getByTestId("workbench-shell")).toBeVisible({ timeout: 30_000 });
+}
+
+async function pickNamespace(page: Page, name: string): Promise<void> {
+  await page.getByTestId("namespace-select").click();
+  const filter = page.getByTestId("namespace-filter");
+  await filter.fill(name);
+  await page.locator(".namespace-combobox-item", { hasText: name }).first().click();
+}
+
+async function openHelmRelease(page: Page): Promise<void> {
+  await page.getByTestId("tool-nav-helm").click();
+  const row = page.getByTestId(`helm-release-${RELEASE}`);
+  await expect(row).toBeVisible({ timeout: 30_000 });
+  await row.click();
+  await expect(page.getByTestId("helm-detail")).toBeVisible({ timeout: 30_000 });
+}
+
+test.beforeEach(async ({ page }) => {
+  await installLiveCore(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+});
+
+test("namespace scope carries over from another view to Helm", async ({ page }) => {
+  await connect(page);
+  await pickNamespace(page, NAMESPACE);
+  await expect(page.getByTestId("namespace-select")).toContainText(NAMESPACE);
+
+  await page.getByTestId("tool-nav-helm").click();
+  const view = page.getByTestId("helm-view");
+  await expect(view).toBeVisible();
+  // The picker must still say the carried-over namespace, and the list must
+  // contain the release that lives in it.
+  await expect(page.getByTestId("namespace-select")).toContainText(NAMESPACE);
+  await expect(view.getByTestId(`helm-release-${RELEASE}`)).toBeVisible({ timeout: 30_000 });
+});
+
+test("helm release detail closes when the namespace scope switches", async ({ page }) => {
+  await connect(page);
+  await pickNamespace(page, NAMESPACE);
+  await openHelmRelease(page);
+
+  await pickNamespace(page, "All namespaces");
+  await expect(page.getByTestId("helm-detail")).toHaveCount(0);
+  const view = page.getByTestId("helm-view");
+  await expect(view.getByTestId("helm-table")).toBeVisible();
+  // The release is still reachable from the all-namespaces list.
+  await expect(view.getByTestId(`helm-release-${RELEASE}`)).toBeVisible({ timeout: 30_000 });
+});
+
+test("upgrade dialog renders chart defaults in the left pane", async ({ page }) => {
+  await connect(page);
+  await pickNamespace(page, NAMESPACE);
+  await openHelmRelease(page);
+
+  await page.getByTestId("helm-upgrade").click();
+  const dialog = page.getByTestId("helm-upgrade-dialog");
+  await expect(dialog).toBeVisible();
+  const defaults = page.getByTestId("helm-upgrade-defaults");
+  await expect(defaults).toBeVisible();
+  await expect(defaults).not.toContainText("ships no default values");
+  await expect(defaults).toContainText("replicas");
+  // Read-only check: close without submitting.
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+});

--- a/apps/desktop/tests/live/shim.ts
+++ b/apps/desktop/tests/live/shim.ts
@@ -1,0 +1,262 @@
+/**
+ * Live web-test shim for the desktop API. Injected into the Vite-served
+ * renderer by Playwright (desktop.ts prefers window.__ASTER_DESKTOP__ over
+ * the Tauri transport), so the real app UI runs in a plain browser while all
+ * core calls go to the REAL running sidecar through a same-origin /__core__
+ * prefix that the Playwright route in support.ts proxies with the bearer
+ * token. The token itself never enters page JavaScript.
+ *
+ * Method-for-method this mirrors renderer/lib/desktop-tauri.ts; two surfaces
+ * are simplified for the harness:
+ *   - resources.watch delivers the initial list snapshot only (no live
+ *     deltas): the proxy fulfills whole responses, so a never-ending ndjson
+ *     stream cannot pass through it. Tables render; live updates do not.
+ *   - Shell-only features (native dialogs, updater, log follow, exec,
+ *     port-forward) are inert stubs — tests must not depend on them.
+ */
+import type {
+  DesktopApi,
+  HelmReleaseDetail,
+  HelmReleaseSummary,
+  NamespaceInfo,
+  Overview,
+  ResourceListRequest,
+  ResourceWatchBatch,
+} from "../../src/shared/types";
+import {
+  type CoreListResponse,
+  type CoreOverview,
+  type CoreResourceRow,
+  discoveredResourceList,
+  normalizeRow,
+  podMetricList,
+  relatedResourceList,
+  resourceEventList,
+} from "../../src/shared/normalize";
+
+async function parseCoreResponse(response: Response, path: string): Promise<unknown> {
+  const text = await response.text();
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`;
+    try {
+      const body = JSON.parse(text) as { error?: { message?: string } };
+      if (body.error?.message) message = body.error.message;
+    } catch {
+      if (text) message = text.slice(0, 200);
+    }
+    throw new Error(`core ${path}: ${message}`);
+  }
+  return text ? JSON.parse(text) : {};
+}
+
+async function coreGet(path: string): Promise<any> {
+  return parseCoreResponse(await fetch(`/__core__${path}`), path);
+}
+
+async function corePost(path: string, body: unknown): Promise<any> {
+  return parseCoreResponse(await fetch(`/__core__${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+  }), path);
+}
+
+function gvr(kind: ResourceListRequest["resourceKind"]): { group: string; version: string; resource: string } {
+  return { group: kind.group, version: kind.version, resource: kind.resource };
+}
+
+function unsupported(name: string): Promise<never> {
+  return Promise.reject(new Error(`${name} is not available in the live web harness`));
+}
+
+/** Mirrors the Rust namespaces_list pager: full inventory, {name,status} rows. */
+async function listAllNamespaces(contextId: string): Promise<{ namespaces: NamespaceInfo[]; truncated: boolean }> {
+  const namespaces: NamespaceInfo[] = [];
+  let continueToken = "";
+  let truncated = false;
+  for (let page = 0; page < 40; page += 1) {
+    let query = `contextId=${encodeURIComponent(contextId)}&limit=5000`;
+    if (continueToken) query += `&continueToken=${encodeURIComponent(continueToken)}`;
+    let value: any;
+    try {
+      value = await coreGet(`/v1/namespaces?${query}`);
+    } catch {
+      truncated = true;
+      break;
+    }
+    for (const item of value.items ?? []) {
+      namespaces.push({ name: item.name, ...(item.status ? { status: item.status } : {}) } as NamespaceInfo);
+    }
+    continueToken = typeof value.continueToken === "string" ? value.continueToken : "";
+    if (!continueToken) break;
+  }
+  return { namespaces, truncated: truncated || Boolean(continueToken) };
+}
+
+const api: DesktopApi = {
+  platform: "darwin",
+  app: {
+    version: () => Promise.resolve("live-web"),
+    onCommand: () => () => {},
+    openExternal: () => Promise.resolve(),
+  },
+  updater: {
+    state: () => Promise.resolve({ state: "idle", currentVersion: "live-web" }),
+    check: () => Promise.resolve(),
+    download: () => Promise.resolve(),
+    install: () => Promise.resolve(),
+    onState: () => () => {},
+  },
+  appearance: {
+    setThemeSource: () => Promise.resolve(),
+  },
+  files: {
+    saveTextFile: () => Promise.resolve(null),
+  },
+  core: {
+    status: () => Promise.resolve({ state: "ready" }),
+    onStatus: () => () => {},
+  },
+  contexts: {
+    list: async () => (await coreGet("/v1/contexts")).contexts ?? [],
+    sourcesReport: () => coreGet("/v1/sources"),
+    renameConflict: async (request) => { await corePost("/v1/sources/rename", request); },
+  },
+  settings: {
+    get: () => Promise.resolve({ kubeconfigSources: [], includeStandardChain: false }),
+    setKubeconfigSources: (sources, includeStandardChain) => Promise.resolve({ kubeconfigSources: sources, includeStandardChain }),
+    pickKubeconfigFile: () => Promise.resolve(null),
+    pickKubeconfigFolder: () => Promise.resolve(null),
+    applyKubeconfigSources: () => Promise.resolve(),
+  },
+  discovery: {
+    list: async (contextId) => discoveredResourceList(await coreGet(`/v1/discovery?contextId=${encodeURIComponent(contextId)}`)),
+  },
+  namespaces: {
+    list: (contextId) => listAllNamespaces(contextId),
+  },
+  metrics: {
+    pods: async (contextId, namespace) => podMetricList(await corePost("/v1/metrics/pods", { contextId, namespace })),
+  },
+  overview: {
+    get: async (contextId): Promise<Overview> => {
+      const value = (await coreGet(`/v1/overview?contextId=${encodeURIComponent(contextId)}`)) as CoreOverview;
+      return {
+        nodes: value.nodes,
+        pods: value.pods,
+        namespaces: value.namespaces,
+        services: value.services,
+        resource: value.resource,
+        events: (value.events || []).map((event) => ({ ...event, namespace: event.namespace || "" })),
+        ...(value.truncated ? { truncated: true } : {}),
+      };
+    },
+  },
+  helm: {
+    list: async (contextId, namespace): Promise<HelmReleaseSummary[]> => {
+      const value = await coreGet(`/v1/helm/releases?contextId=${encodeURIComponent(contextId)}&namespace=${encodeURIComponent(namespace)}`);
+      return value.releases ?? [];
+    },
+    get: async (request): Promise<HelmReleaseDetail> => (await corePost("/v1/helm/releases/get", request)).release,
+    uninstall: async (request) => { await corePost("/v1/helm/releases/uninstall", request); },
+    rollback: async (request) => { await corePost("/v1/helm/releases/rollback", request); },
+    upgrade: (request) => corePost("/v1/helm/releases/upgrade", request),
+  },
+  resources: {
+    list: async (request) => {
+      const response = (await corePost("/v1/resources/list", {
+        contextId: request.contextId,
+        gvr: gvr(request.resourceKind),
+        namespace: request.namespace,
+        limit: request.limit,
+        continueToken: request.continueToken,
+        labelSelector: request.labelSelector,
+        fieldSelector: request.fieldSelector,
+      })) as CoreListResponse;
+      return {
+        items: response.items.map(normalizeRow),
+        ...(response.continueToken ? { continueToken: response.continueToken } : {}),
+        ...(response.resourceVersion ? { resourceVersion: response.resourceVersion } : {}),
+      };
+    },
+    get: async (request) => {
+      const response = await corePost("/v1/resources/get", {
+        contextId: request.contextId,
+        gvr: gvr(request.resourceKind),
+        namespace: request.namespace,
+        name: request.name,
+      });
+      return { row: normalizeRow(response.resource as CoreResourceRow), yaml: response.yaml };
+    },
+    events: async (request) => {
+      const response = (await corePost("/v1/resources/list", {
+        contextId: request.contextId,
+        gvr: { group: "", version: "v1", resource: "events" },
+        namespace: request.namespace,
+        limit: 100,
+        fieldSelector: `involvedObject.name=${request.name}`,
+      })) as CoreListResponse;
+      return resourceEventList(response.items);
+    },
+    related: async (request) => relatedResourceList(await corePost("/v1/resources/related", {
+      contextId: request.contextId,
+      gvr: gvr(request.resourceKind),
+      namespace: request.namespace,
+      name: request.name,
+    })),
+    search: async (request) => relatedResourceList(await corePost("/v1/resources/search", {
+      contextId: request.contextId,
+      query: request.query,
+      namespace: request.namespace,
+    })),
+    logs: (request) => corePost("/v1/pods/logs", request),
+    followLogs: () => () => {},
+    workloadLogs: (request) => corePost("/v1/workloads/logs", request),
+    followWorkloadLogs: () => () => {},
+    portForwardStart: () => unsupported("portForwardStart"),
+    portForwardStop: () => Promise.resolve(),
+    exec: () => unsupported("exec"),
+    mutate: (request) => corePost("/v1/resources/mutate", {
+      contextId: request.contextId,
+      gvr: gvr(request.resourceKind),
+      namespace: request.namespace,
+      name: request.name,
+      operation: request.operation,
+      replicas: request.replicas,
+      image: request.image,
+      container: request.container,
+      yaml: request.yaml,
+      dryRun: request.dryRun,
+      resourceVersion: request.resourceVersion,
+    }),
+    // Snapshot-only watch: one list call delivered as a snapshot batch, no
+    // live deltas (the /__core__ proxy cannot relay a never-ending stream).
+    watch: (request, listener) => {
+      let active = true;
+      corePost("/v1/resources/list", {
+        contextId: request.contextId,
+        gvr: gvr(request.resourceKind),
+        namespace: request.namespace,
+        limit: request.limit ?? 500,
+        labelSelector: request.labelSelector,
+        fieldSelector: request.fieldSelector,
+      }).then((response: CoreListResponse) => {
+        if (!active) return;
+        const batch: ResourceWatchBatch = {
+          subscriptionId: "live-watch",
+          kind: "snapshot",
+          items: response.items.map(normalizeRow),
+          ...(response.continueToken ? { continueToken: response.continueToken } : {}),
+          ...(response.resourceVersion ? { resourceVersion: response.resourceVersion } : {}),
+        };
+        listener(batch);
+      }).catch((cause: unknown) => {
+        if (!active) return;
+        listener({ subscriptionId: "live-watch", kind: "error", message: cause instanceof Error ? cause.message : String(cause) });
+      });
+      return () => { active = false; };
+    },
+  },
+};
+
+(window as unknown as { __ASTER_DESKTOP__: DesktopApi }).__ASTER_DESKTOP__ = api;

--- a/apps/desktop/tests/live/support.ts
+++ b/apps/desktop/tests/live/support.ts
@@ -1,0 +1,88 @@
+/**
+ * Node-side support for the live web harness: bundles tests/live/shim.ts into
+ * an init script and installs a same-origin /__core__ proxy that forwards to
+ * the real running sidecar with its bearer token. The token comes from
+ * ASTER_LIVE_TOKEN (populated by scripts/test-live-web.sh from the sidecar
+ * process environment) and stays in the Playwright Node process — page
+ * JavaScript only ever sees same-origin requests.
+ */
+import { buildSync } from "esbuild";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+let cachedShim: string | undefined;
+
+export function shimScript(): string {
+  if (!cachedShim) {
+    const result = buildSync({
+      entryPoints: [path.join(here, "shim.ts")],
+      bundle: true,
+      write: false,
+      format: "iife",
+      platform: "browser",
+    });
+    cachedShim = result.outputFiles[0].text;
+  }
+  return cachedShim;
+}
+
+function liveCoreCredentials(): { base: string; token: string } {
+  const base = process.env.ASTER_LIVE_CORE_URL;
+  const token = process.env.ASTER_LIVE_TOKEN;
+  if (!base || !token) {
+    throw new Error("live web tests need ASTER_LIVE_CORE_URL and ASTER_LIVE_TOKEN; run via scripts/test-live-web.sh");
+  }
+  return { base, token };
+}
+
+/**
+ * Mutation endpoints the live harness refuses to proxy by default. The live
+ * suite is read-only against the cluster; a future test that genuinely needs
+ * a mutation must opt in with ASTER_LIVE_ALLOW_MUTATIONS=1.
+ */
+const MUTATION_PATHS = new Set([
+  "/v1/resources/mutate",
+  "/v1/helm/releases/uninstall",
+  "/v1/helm/releases/rollback",
+  "/v1/helm/releases/upgrade",
+  "/v1/sources/rename",
+  "/v1/pods/exec",
+  "/v1/pods/portforward",
+  "/v1/pods/portforward/stop",
+]);
+
+export async function installLiveCore(page: Page): Promise<void> {
+  const { base, token } = liveCoreCredentials();
+  const allowMutations = process.env.ASTER_LIVE_ALLOW_MUTATIONS === "1";
+  await page.addInitScript(shimScript());
+  await page.route("**/__core__/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname.replace(/^\/__core__/, "");
+    if (!allowMutations && MUTATION_PATHS.has(path)) {
+      await route.fulfill({
+        status: 403,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { code: "live_read_only", message: `live web harness is read-only; ${path} requires ASTER_LIVE_ALLOW_MUTATIONS=1` } }),
+      });
+      return;
+    }
+    const target = `${base}${path}${url.search}`;
+    const response = await fetch(target, {
+      method: request.method(),
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: request.method() === "POST" ? request.postData() ?? "{}" : undefined,
+    });
+    await route.fulfill({
+      status: response.status,
+      contentType: response.headers.get("content-type") ?? "application/json",
+      body: await response.text(),
+    });
+  });
+}

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -233,7 +233,15 @@ const MOCK_DESKTOP_API = `
       }),
       uninstall: async () => undefined,
       rollback: async () => undefined,
-      upgrade: async () => ({ revision: 4 }),
+      upgrade: async (request) => {
+        // A real upgrade takes time; the delay keeps the busy state
+        // observable, and the marker exercises the failure path.
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        if ((request.values || "").includes("cluster-is-down")) {
+          throw new Error("simulated upgrade failure");
+        }
+        return { revision: 4 };
+      },
     },
     resources: {
       list: async (request) => pageOf(request),
@@ -1093,13 +1101,48 @@ test("helm view lists releases and opens a detail", async ({ page }) => {
   await expectNoOverflow(page, "helm upgrade review 1280x800");
   await screenshot(page, "helm-upgrade-1280");
   await upgradeDialog.getByTestId("helm-upgrade-submit").click();
-  await expect(view.getByTestId("helm-message")).toContainText("upgraded to revision 4");
+  // While the upgrade runs the confirm button shows progress and the dialog
+  // refuses to be dismissed; on success it closes by itself.
+  await expect(upgradeDialog.getByTestId("helm-upgrade-submit")).toContainText("Upgrading");
+  await page.keyboard.press("Escape");
+  await expect(upgradeDialog).toBeVisible();
   await expect(upgradeDialog).not.toBeVisible();
+  // The success surfaces as a toast that dismisses itself instead of a
+  // banner lingering on the view.
+  const toast = page.locator('[data-slot="toast"]', { hasText: "upgraded to revision 4" });
+  await expect(toast).toBeVisible();
+  await screenshot(page, "helm-upgrade-toast-1280");
+  await expect(toast).toHaveCount(0, { timeout: 10_000 });
 
   // The unified toolbar back returns to the release list; the helm tab stays active.
   await page.getByTestId("toolbar-back").click();
   await expect(page.getByTestId("helm-table")).toBeVisible();
   await expect(view.getByTestId("helm-release-broken")).toBeVisible();
+  expect(failures).toEqual([]);
+});
+
+test("helm upgrade failure keeps the dialog open with the error", async ({ page }) => {
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await connectToDev(page);
+
+  await page.getByTestId("tool-nav-helm").click();
+  const view = page.getByTestId("helm-view");
+  await view.getByTestId("helm-release-web").click();
+  await page.getByTestId("helm-detail").getByTestId("helm-upgrade").click();
+  const dialog = page.getByTestId("helm-upgrade-dialog");
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByTestId("helm-upgrade-values").fill("cluster-is-down: true");
+  await dialog.getByTestId("helm-upgrade-review").click();
+  await dialog.getByTestId("helm-upgrade-submit").click();
+  // The failure surfaces inside the dialog — not on the detail view hidden
+  // behind it — and the dialog stays open so the values can be adjusted and
+  // retried. No success toast is posted.
+  await expect(dialog.getByTestId("helm-upgrade-error")).toContainText("simulated upgrade failure");
+  await expect(dialog).toBeVisible();
+  await expect(page.locator('[data-slot="toast"]')).toHaveCount(0);
   expect(failures).toEqual([]);
 });
 

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -1184,6 +1184,28 @@ test("helm view lists releases across namespaces when the picker is on All names
   expect(failures).toEqual([]);
 });
 
+test("helm detail closes when the namespace picker switches scope", async ({ page }) => {
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await connectToDev(page);
+
+  await page.getByTestId("tool-nav-helm").click();
+  const view = page.getByTestId("helm-view");
+  await view.getByTestId("helm-release-web").click();
+  await expect(page.getByTestId("helm-detail")).toBeVisible();
+
+  // Switching the shared namespace picker resets the helm list scope; the
+  // open detail belongs to the old scope and must close back to the list,
+  // matching how resource details behave.
+  await page.getByTestId("namespace-select").click();
+  await page.locator(".namespace-combobox-item", { hasText: "All namespaces" }).click();
+  await expect(page.getByTestId("helm-detail")).toHaveCount(0);
+  await expect(view.getByTestId("helm-table")).toBeVisible();
+  await expect(view.getByTestId("helm-release-web")).toBeVisible();
+  expect(failures).toEqual([]);
+});
+
 async function screenshot(page: Page, name: string): Promise<void> {
   const directory = path.join(process.cwd(), "..", "..", "output", "playwright");
   fs.mkdirSync(directory, { recursive: true });

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -230,6 +230,7 @@ const MOCK_DESKTOP_API = `
       }),
       uninstall: async () => undefined,
       rollback: async () => undefined,
+      upgrade: async () => ({ revision: 4 }),
     },
     resources: {
       list: async (request) => pageOf(request),
@@ -1063,6 +1064,21 @@ test("helm view lists releases and opens a detail", async ({ page }) => {
   await expect(detail.getByTestId("helm-uninstall")).toBeVisible();
   await expectNoOverflow(page, "helm detail 1280x800");
   await screenshot(page, "helm-detail-1280");
+
+  // Upgrade opens the form prefilled from the current release.
+  await detail.getByTestId("helm-upgrade").click();
+  const upgradeDialog = page.getByTestId("helm-upgrade-dialog");
+  await expect(upgradeDialog).toBeVisible();
+  await expect(upgradeDialog.getByTestId("helm-upgrade-chart")).toHaveValue("web");
+  await expect(upgradeDialog.getByTestId("helm-upgrade-version")).toHaveValue("1.2.3");
+  await expect(upgradeDialog.getByTestId("helm-upgrade-values")).toHaveValue("replicas: 2");
+  await expect(upgradeDialog.getByTestId("helm-upgrade-submit")).toBeDisabled();
+  await upgradeDialog.getByTestId("helm-upgrade-repo-url").fill("https://charts.example.test");
+  await expectNoOverflow(page, "helm upgrade dialog 1280x800");
+  await screenshot(page, "helm-upgrade-1280");
+  await upgradeDialog.getByTestId("helm-upgrade-submit").click();
+  await expect(view.getByTestId("helm-message")).toContainText("upgraded to revision 4");
+  await expect(upgradeDialog).not.toBeVisible();
 
   // Back returns to the release list; the helm tab stays active.
   await detail.getByTestId("helm-back").click();

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -207,8 +207,10 @@ const MOCK_DESKTOP_API = `
     },
     helm: {
       list: async (_contextId, namespace) => [
-        { name: "web", namespace, version: 3, status: "deployed", chart: "web", chartVersion: "1.2.3", appVersion: "7.0", updatedAt: "2026-08-01T00:00:00Z", description: "Install complete" },
-        { name: "broken", namespace, version: 1, status: "failed", chart: "broken", chartVersion: "0.1.0", appVersion: "1.0", updatedAt: "2026-08-02T00:00:00Z" },
+        // An empty namespace means all namespaces; surface releases from
+        // distinct namespaces so the All-namespaces list is distinguishable.
+        { name: "web", namespace: namespace || "apps", version: 3, status: "deployed", chart: "web", chartVersion: "1.2.3", appVersion: "7.0", updatedAt: "2026-08-01T00:00:00Z", description: "Install complete" },
+        { name: "broken", namespace: namespace || "default", version: 1, status: "failed", chart: "broken", chartVersion: "0.1.0", appVersion: "1.0", updatedAt: "2026-08-02T00:00:00Z" },
       ],
       get: async (request) => ({
         name: request.name,
@@ -1152,6 +1154,33 @@ test("namespace picker refetches the list after each context switch", async ({ p
   await openPicker();
   await expect(namespaceItem("kube-system")).toBeVisible();
   await screenshot(page, "namespace-picker-after-context-switch");
+  expect(failures).toEqual([]);
+});
+
+test("helm view lists releases across namespaces when the picker is on All namespaces", async ({ page }) => {
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await connectToDev(page);
+
+  // Set the top namespace picker to "All namespaces" so the list is empty.
+  await page.getByTestId("namespace-select").click();
+  const allNs = page.locator(".namespace-combobox-item", { hasText: "All namespaces" });
+  await allNs.click();
+
+  await page.getByTestId("tool-nav-helm").click();
+  const view = page.getByTestId("helm-view");
+  await expect(view).toBeVisible();
+  // An empty namespace now lists across namespaces: distinct namespaces.
+  const web = view.getByTestId("helm-release-web");
+  await expect(web).toContainText("deployed");
+  // Clicking a release uses the release's own namespace, not the empty picker.
+  await web.click();
+  const detail = page.getByTestId("helm-detail");
+  await expect(detail).toBeVisible();
+  await expect(detail).toContainText("apps");
+  await expectNoOverflow(page, "helm all-namespaces 1280x800");
+  await screenshot(page, "helm-all-namespaces-1280");
   expect(failures).toEqual([]);
 });
 

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -223,6 +223,7 @@ const MOCK_DESKTOP_API = `
         updatedAt: "2026-08-01T00:00:00Z",
         description: "Install complete",
         values: "replicas: 2",
+        chartValues: "replicas: 1\\nimagePullPolicy: Always\\n",
         manifest: "apiVersion: v1\\nkind: ConfigMap\\nmetadata:\\n  name: web-cm\\n",
         truncated: false,
         history: [
@@ -1054,36 +1055,49 @@ test("helm view lists releases and opens a detail", async ({ page }) => {
   await expectNoOverflow(page, "helm list 1280x800");
   await screenshot(page, "helm-list-1280");
 
-  // Selecting a release opens the read view: values, manifest, history.
+  // Selecting a release opens the tabbed detail: a card-based overview with
+  // vitals, information, and revision history; values and manifest get tabs.
   await view.getByTestId("helm-release-web").click();
   const detail = page.getByTestId("helm-detail");
   await expect(detail).toBeVisible();
   await expect(detail).toContainText("web");
-  await expect(detail.getByTestId("helm-values")).toContainText("replicas");
-  await expect(detail.getByTestId("helm-manifest")).toContainText("ConfigMap");
+  await expect(detail.getByTestId("helm-vitals")).toContainText("1.2.3");
+  await expect(detail.getByTestId("helm-meta")).toContainText("Install complete");
   await expect(detail.getByTestId("helm-history")).toContainText("v3");
   await expect(detail.getByTestId("helm-rollback")).toBeVisible();
   await expect(detail.getByTestId("helm-uninstall")).toBeVisible();
   await expectNoOverflow(page, "helm detail 1280x800");
   await screenshot(page, "helm-detail-1280");
 
-  // Upgrade opens the form prefilled from the current release.
+  await detail.getByRole("tab", { name: "Values" }).click();
+  await expect(detail.getByTestId("helm-values")).toContainText("replicas");
+  await detail.getByRole("tab", { name: "Manifest" }).click();
+  await expect(detail.getByTestId("helm-manifest")).toContainText("ConfigMap");
+
+  // Upgrade is a two-step review: edit values, review the diff, confirm.
+  // Leaving the repository empty reuses the installed chart, so the chart
+  // and version inputs stay disabled.
   await detail.getByTestId("helm-upgrade").click();
   const upgradeDialog = page.getByTestId("helm-upgrade-dialog");
   await expect(upgradeDialog).toBeVisible();
   await expect(upgradeDialog.getByTestId("helm-upgrade-chart")).toHaveValue("web");
-  await expect(upgradeDialog.getByTestId("helm-upgrade-version")).toHaveValue("1.2.3");
+  await expect(upgradeDialog.getByTestId("helm-upgrade-chart")).toBeDisabled();
+  await expect(upgradeDialog.getByTestId("helm-upgrade-version")).toBeDisabled();
   await expect(upgradeDialog.getByTestId("helm-upgrade-values")).toHaveValue("replicas: 2");
-  await expect(upgradeDialog.getByTestId("helm-upgrade-submit")).toBeDisabled();
-  await upgradeDialog.getByTestId("helm-upgrade-repo-url").fill("https://charts.example.test");
-  await expectNoOverflow(page, "helm upgrade dialog 1280x800");
+  // Chart defaults sit read-only beside the editable values (Kite-style split).
+  await expect(upgradeDialog.getByTestId("helm-upgrade-defaults")).toContainText("replicas: 1");
+  await upgradeDialog.getByTestId("helm-upgrade-values").fill("replicas: 3");
+  await upgradeDialog.getByTestId("helm-upgrade-review").click();
+  await expect(upgradeDialog.getByTestId("helm-upgrade-summary")).toContainText("Reuses the installed chart");
+  await expect(upgradeDialog.getByTestId("helm-upgrade-diff")).toContainText("replicas");
+  await expectNoOverflow(page, "helm upgrade review 1280x800");
   await screenshot(page, "helm-upgrade-1280");
   await upgradeDialog.getByTestId("helm-upgrade-submit").click();
   await expect(view.getByTestId("helm-message")).toContainText("upgraded to revision 4");
   await expect(upgradeDialog).not.toBeVisible();
 
-  // Back returns to the release list; the helm tab stays active.
-  await detail.getByTestId("helm-back").click();
+  // The unified toolbar back returns to the release list; the helm tab stays active.
+  await page.getByTestId("toolbar-back").click();
   await expect(page.getByTestId("helm-table")).toBeVisible();
   await expect(view.getByTestId("helm-release-broken")).toBeVisible();
   expect(failures).toEqual([]);

--- a/core/internal/helm/service.go
+++ b/core/internal/helm/service.go
@@ -152,13 +152,19 @@ func (s *Service) Get(ctx context.Context, request GetRequest) (GetResponse, err
 		manifest = redactManifest(manifest)
 	}
 	values, valuesTruncated := capText(valuesYAML(item.Config))
+	chartValues := ""
+	chartValuesTruncated := false
+	if item.Chart != nil {
+		chartValues, chartValuesTruncated = capText(valuesYAML(item.Chart.Values))
+	}
 	notes, _ := capText(item.Info.Notes)
 	detail := ReleaseDetail{
 		ReleaseSummary: summarize(item),
 		Notes:          notes,
 		Values:         values,
 		Manifest:       manifest,
-		Truncated:      manifestTruncated || valuesTruncated,
+		ChartValues:    chartValues,
+		Truncated:      manifestTruncated || valuesTruncated || chartValuesTruncated,
 		History:        history,
 	}
 	return GetResponse{Release: detail}, nil
@@ -226,9 +232,6 @@ func (s *Service) Upgrade(ctx context.Context, request UpgradeRequest) (UpgradeR
 	if request.ContextID == "" || request.Namespace == "" || request.Name == "" {
 		return UpgradeResponse{}, invalid("contextId, namespace and name are required")
 	}
-	if strings.TrimSpace(request.RepoURL) == "" || strings.TrimSpace(request.Chart) == "" {
-		return UpgradeResponse{}, invalid("repoUrl and chart are required")
-	}
 	values := map[string]any{}
 	if strings.TrimSpace(request.Values) != "" {
 		if err := yaml.Unmarshal([]byte(request.Values), &values); err != nil {
@@ -241,11 +244,34 @@ func (s *Service) Upgrade(ctx context.Context, request UpgradeRequest) (UpgradeR
 	}
 	client := action.NewUpgrade(config)
 	client.Timeout = 5 * time.Minute
-	client.RepoURL = request.RepoURL
-	client.Version = request.Version
-	loaded, err := s.loadChart(client.ChartPathOptions, request.Chart)
-	if err != nil {
-		return UpgradeResponse{}, err
+
+	var loaded *chart.Chart
+	if strings.TrimSpace(request.RepoURL) == "" {
+		// Values-only upgrade: releases store their chart's full contents, so an
+		// empty repoUrl reuses that stored chart instead of re-pulling one. The
+		// chart and version inputs are meaningless here and ignored.
+		existing, err := action.NewGet(config).Run(request.Name)
+		if err != nil {
+			if isNotFound(err) {
+				return UpgradeResponse{}, notFound(fmt.Sprintf("release %q was not found", request.Name))
+			}
+			return UpgradeResponse{}, fmt.Errorf("load stored chart for release %q: %w", request.Name, err)
+		}
+		if existing.Chart == nil {
+			return UpgradeResponse{}, invalid(fmt.Sprintf("release %q has no stored chart; repoUrl and chart are required", request.Name))
+		}
+		loaded = existing.Chart
+	} else {
+		if strings.TrimSpace(request.Chart) == "" {
+			return UpgradeResponse{}, invalid("chart is required when repoUrl is set")
+		}
+		client.RepoURL = request.RepoURL
+		client.Version = request.Version
+		resolved, err := s.loadChart(client.ChartPathOptions, request.Chart)
+		if err != nil {
+			return UpgradeResponse{}, err
+		}
+		loaded = resolved
 	}
 	upgraded, err := client.RunWithContext(ctx, request.Name, loaded, values)
 	if err != nil {

--- a/core/internal/helm/service.go
+++ b/core/internal/helm/service.go
@@ -90,9 +90,6 @@ func (s *Service) configuration(ctx context.Context, contextID, namespace string
 	if strings.TrimSpace(contextID) == "" {
 		return nil, invalid("contextId is required")
 	}
-	if strings.TrimSpace(namespace) == "" {
-		return nil, invalid("namespace is required")
-	}
 	raw, err := s.clients.ClientConfig(contextID)
 	if err != nil {
 		return nil, fmt.Errorf("load context %q: %w", contextID, err)
@@ -105,8 +102,8 @@ func (s *Service) configuration(ctx context.Context, contextID, namespace string
 }
 
 func (s *Service) List(ctx context.Context, request ListRequest) (ListResponse, error) {
-	if request.ContextID == "" || request.Namespace == "" {
-		return ListResponse{}, invalid("contextId and namespace are required")
+	if request.ContextID == "" {
+		return ListResponse{}, invalid("contextId is required")
 	}
 	config, err := s.configuration(ctx, request.ContextID, request.Namespace)
 	if err != nil {
@@ -116,6 +113,9 @@ func (s *Service) List(ctx context.Context, request ListRequest) (ListResponse, 
 	client.StateMask = action.ListDeployed | action.ListFailed
 	client.ByDate = true
 	client.SortReverse = true
+	// An empty namespace means every namespace (helm list -A semantics): the
+	// secret driver lists across namespaces when the lazy client's namespace
+	// is empty, so empty namespace flows through configuration() unmodified.
 	releases, err := client.Run()
 	if err != nil {
 		return ListResponse{}, fmt.Errorf("list releases: %w", err)

--- a/core/internal/helm/service.go
+++ b/core/internal/helm/service.go
@@ -269,7 +269,10 @@ func (s *Service) Upgrade(ctx context.Context, request UpgradeRequest) (UpgradeR
 		client.Version = request.Version
 		resolved, err := s.loadChart(client.ChartPathOptions, request.Chart)
 		if err != nil {
-			return UpgradeResponse{}, err
+			// Charts resolve through the user's local helm settings
+			// (repositories.yaml and credentials), so a lookup failure usually
+			// means the repository was never configured locally.
+			return UpgradeResponse{}, fmt.Errorf("pull chart %q from %q: %w; verify the repository is added to your local helm config (helm repo add)", request.Chart, request.RepoURL, err)
 		}
 		loaded = resolved
 	}

--- a/core/internal/helm/service.go
+++ b/core/internal/helm/service.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -36,6 +39,9 @@ type Service struct {
 	// newConfiguration replaces the real client wiring in tests so the
 	// service can run against an in-memory Helm storage without a cluster.
 	newConfiguration func(ctx context.Context, contextID, namespace string) (*action.Configuration, error)
+	// locateChart replaces chart resolution in tests so upgrades run without
+	// a chart repository.
+	locateChart func(options action.ChartPathOptions, name string) (*chart.Chart, error)
 }
 
 func NewService(clients ClientConfigProvider) *Service {
@@ -198,6 +204,59 @@ func (s *Service) Uninstall(ctx context.Context, request UninstallRequest) (Unin
 	return UninstallResponse{Info: info}, nil
 }
 
+// loadChart resolves the upgrade chart through the user's local Helm
+// settings (repository config and credentials, matching the helm CLI), or
+// through the injected fake in tests.
+func (s *Service) loadChart(options action.ChartPathOptions, name string) (*chart.Chart, error) {
+	if s.locateChart != nil {
+		return s.locateChart(options, name)
+	}
+	path, err := options.LocateChart(name, cli.New())
+	if err != nil {
+		return nil, fmt.Errorf("locate chart %q: %w", name, err)
+	}
+	loaded, err := loader.Load(path)
+	if err != nil {
+		return nil, fmt.Errorf("load chart %q: %w", name, err)
+	}
+	return loaded, nil
+}
+
+func (s *Service) Upgrade(ctx context.Context, request UpgradeRequest) (UpgradeResponse, error) {
+	if request.ContextID == "" || request.Namespace == "" || request.Name == "" {
+		return UpgradeResponse{}, invalid("contextId, namespace and name are required")
+	}
+	if strings.TrimSpace(request.RepoURL) == "" || strings.TrimSpace(request.Chart) == "" {
+		return UpgradeResponse{}, invalid("repoUrl and chart are required")
+	}
+	values := map[string]any{}
+	if strings.TrimSpace(request.Values) != "" {
+		if err := yaml.Unmarshal([]byte(request.Values), &values); err != nil {
+			return UpgradeResponse{}, invalid(fmt.Sprintf("values is not valid YAML: %v", err))
+		}
+	}
+	config, err := s.configuration(ctx, request.ContextID, request.Namespace)
+	if err != nil {
+		return UpgradeResponse{}, err
+	}
+	client := action.NewUpgrade(config)
+	client.Timeout = 5 * time.Minute
+	client.RepoURL = request.RepoURL
+	client.Version = request.Version
+	loaded, err := s.loadChart(client.ChartPathOptions, request.Chart)
+	if err != nil {
+		return UpgradeResponse{}, err
+	}
+	upgraded, err := client.RunWithContext(ctx, request.Name, loaded, values)
+	if err != nil {
+		if isNotFound(err) {
+			return UpgradeResponse{}, notFound(fmt.Sprintf("release %q was not found", request.Name))
+		}
+		return UpgradeResponse{}, fmt.Errorf("upgrade release %q: %w", request.Name, err)
+	}
+	return UpgradeResponse{Revision: upgraded.Version}, nil
+}
+
 func (s *Service) Rollback(ctx context.Context, request RollbackRequest) (RollbackResponse, error) {
 	if request.ContextID == "" || request.Namespace == "" || request.Name == "" {
 		return RollbackResponse{}, invalid("contextId, namespace and name are required")
@@ -264,5 +323,7 @@ func capText(value string) (string, bool) {
 }
 
 func isNotFound(err error) bool {
-	return errors.Is(err, driver.ErrReleaseNotFound)
+	// Upgrade reports a missing release as ErrNoDeployedReleases instead of
+	// ErrReleaseNotFound; both mean the renderer should show not-found.
+	return errors.Is(err, driver.ErrReleaseNotFound) || errors.Is(err, driver.ErrNoDeployedReleases)
 }

--- a/core/internal/helm/service_test.go
+++ b/core/internal/helm/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
+	chartutil "helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
@@ -22,11 +23,29 @@ func testService(t *testing.T, store *storage.Storage) *Service {
 	t.Helper()
 	service := &Service{newConfiguration: func(context.Context, string, string) (*action.Configuration, error) {
 		return &action.Configuration{
-			KubeClient: &fake.PrintingKubeClient{},
-			Releases:   store,
-			Log:        func(string, ...interface{}) {},
+			KubeClient:   &fake.PrintingKubeClient{},
+			Releases:     store,
+			Capabilities: chartutil.DefaultCapabilities,
+			Log:          func(string, ...interface{}) {},
 		}, nil
 	}}
+	return service
+}
+
+// upgradeService stubs chart resolution with a minimal local chart so
+// upgrades run without a chart repository.
+func upgradeService(t *testing.T, store *storage.Storage) *Service {
+	t.Helper()
+	service := testService(t, store)
+	service.locateChart = func(action.ChartPathOptions, string) (*chart.Chart, error) {
+		return &chart.Chart{
+			Metadata: &chart.Metadata{Name: "web", Version: "1.3.0"},
+			Templates: []*chart.File{{
+				Name: "templates/cm.yaml",
+				Data: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: web-cm\ndata:\n  replicas: \"{{ .Values.replicas }}\"\n"),
+			}},
+		}, nil
+	}
 	return service
 }
 
@@ -145,6 +164,10 @@ func TestServiceRejectsMissingInputs(t *testing.T) {
 		{"uninstall name", UninstallRequest{ContextID: "dev", Namespace: "apps"}},
 		{"rollback name", RollbackRequest{ContextID: "dev", Namespace: "apps"}},
 		{"rollback revision", RollbackRequest{ContextID: "dev", Namespace: "apps", Name: "web", Revision: -1}},
+		{"upgrade name", UpgradeRequest{ContextID: "dev", Namespace: "apps", RepoURL: "https://example.test", Chart: "web"}},
+		{"upgrade repoUrl", UpgradeRequest{ContextID: "dev", Namespace: "apps", Name: "web", Chart: "web"}},
+		{"upgrade chart", UpgradeRequest{ContextID: "dev", Namespace: "apps", Name: "web", RepoURL: "https://example.test"}},
+		{"upgrade values", UpgradeRequest{ContextID: "dev", Namespace: "apps", Name: "web", RepoURL: "https://example.test", Chart: "web", Values: "{{"}},
 	}
 	for _, test := range cases {
 		var err error
@@ -157,6 +180,8 @@ func TestServiceRejectsMissingInputs(t *testing.T) {
 			_, err = service.Uninstall(context.Background(), request)
 		case RollbackRequest:
 			_, err = service.Rollback(context.Background(), request)
+		case UpgradeRequest:
+			_, err = service.Upgrade(context.Background(), request)
 		}
 		var validationErr *ValidationError
 		if err == nil || !errors.As(err, &validationErr) {
@@ -181,6 +206,57 @@ func TestUninstallAndRollbackOnMissingRelease(t *testing.T) {
 	}
 	if !errors.As(err, &notFoundErr) {
 		t.Fatalf("rollback error = %v, want NotFoundError", err)
+	}
+}
+
+func TestUpgradeCreatesNewRevisionWithValues(t *testing.T) {
+	store := testStorage(t)
+	seed(t, store, chartRelease("web", "apps", 1, release.StatusDeployed))
+	service := upgradeService(t, store)
+
+	response, err := service.Upgrade(context.Background(), UpgradeRequest{
+		ContextID: "dev",
+		Namespace: "apps",
+		Name:      "web",
+		RepoURL:   "https://charts.example.test",
+		Chart:     "web",
+		Version:   "1.3.0",
+		Values:    "replicas: 3\n",
+	})
+	if err != nil {
+		t.Fatalf("Upgrade: %v", err)
+	}
+	if response.Revision != 2 {
+		t.Fatalf("revision = %d, want 2", response.Revision)
+	}
+	latest, err := store.Last("web")
+	if err != nil {
+		t.Fatalf("store.Last: %v", err)
+	}
+	if latest.Chart.Metadata.Version != "1.3.0" {
+		t.Fatalf("chart version = %q, want 1.3.0", latest.Chart.Metadata.Version)
+	}
+	// YAML numbers arrive as float64 through the sigs.k8s.io/yaml JSON round trip.
+	if latest.Config["replicas"] != float64(3) {
+		t.Fatalf("config = %#v, want replicas 3", latest.Config)
+	}
+	if !strings.Contains(latest.Manifest, "replicas: \"3\"") {
+		t.Fatalf("manifest did not render new values: %q", latest.Manifest)
+	}
+}
+
+func TestUpgradeRejectsMissingRelease(t *testing.T) {
+	service := upgradeService(t, testStorage(t))
+	_, err := service.Upgrade(context.Background(), UpgradeRequest{
+		ContextID: "dev",
+		Namespace: "apps",
+		Name:      "missing",
+		RepoURL:   "https://charts.example.test",
+		Chart:     "web",
+	})
+	var notFoundErr *NotFoundError
+	if err == nil || !errors.As(err, &notFoundErr) {
+		t.Fatalf("error = %v, want NotFoundError", err)
 	}
 }
 

--- a/core/internal/helm/service_test.go
+++ b/core/internal/helm/service_test.go
@@ -21,7 +21,13 @@ import (
 // cluster.
 func testService(t *testing.T, store *storage.Storage) *Service {
 	t.Helper()
-	service := &Service{newConfiguration: func(context.Context, string, string) (*action.Configuration, error) {
+	service := &Service{newConfiguration: func(_ context.Context, _ string, namespace string) (*action.Configuration, error) {
+		// Mirror configuration.Init: it propagates the namespace to the driver,
+		// so an empty namespace lists across namespaces. Memory supports
+		// SetNamespace; the real secret driver does it via the lazy client.
+		if setter, ok := store.Driver.(interface{ SetNamespace(string) }); ok {
+			setter.SetNamespace(namespace)
+		}
 		return &action.Configuration{
 			KubeClient:   &fake.PrintingKubeClient{},
 			Releases:     store,
@@ -108,6 +114,36 @@ func TestListFiltersByNamespaceAndState(t *testing.T) {
 	}
 }
 
+func TestListAllNamespaces(t *testing.T) {
+	store := testStorage(t)
+	seed(t, store,
+		chartRelease("web", "apps", 1, release.StatusDeployed),
+		chartRelease("api", "apps", 2, release.StatusSuperseded),
+		chartRelease("legacy", "default", 1, release.StatusDeployed),
+		chartRelease("broken", "apps", 1, release.StatusFailed),
+	)
+	service := testService(t, store)
+
+	// An empty namespace means every namespace (helm list -A semantics): the
+	// driver lists across namespaces instead of scoping to one.
+	response, err := service.List(context.Background(), ListRequest{ContextID: "dev"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// The superseded release is filtered out by the state mask, so across
+	// namespaces we get the deployed web/legacy plus the failed broken.
+	if len(response.Releases) != 3 {
+		t.Fatalf("all-namespaces releases = %d, want 3", len(response.Releases))
+	}
+	namespaces := map[string]bool{}
+	for _, item := range response.Releases {
+		namespaces[item.Namespace] = true
+	}
+	if !namespaces["apps"] || !namespaces["default"] {
+		t.Fatalf("all-namespaces release namespaces = %#v", namespaces)
+	}
+}
+
 func TestGetReturnsValuesManifestAndHistory(t *testing.T) {
 	store := testStorage(t)
 	seed(t, store,
@@ -159,7 +195,6 @@ func TestServiceRejectsMissingInputs(t *testing.T) {
 		request any
 	}{
 		{"list context", ListRequest{Namespace: "apps"}},
-		{"list namespace", ListRequest{ContextID: "dev"}},
 		{"get name", GetRequest{ContextID: "dev", Namespace: "apps"}},
 		{"uninstall name", UninstallRequest{ContextID: "dev", Namespace: "apps"}},
 		{"rollback name", RollbackRequest{ContextID: "dev", Namespace: "apps"}},

--- a/core/internal/helm/service_test.go
+++ b/core/internal/helm/service_test.go
@@ -68,7 +68,11 @@ func chartRelease(name, namespace string, version int, status release.Status) *r
 		Namespace: namespace,
 		Version:   version,
 		Info:      &release.Info{Status: status, Description: "test release"},
-		Chart:     &chart.Chart{Metadata: &chart.Metadata{Name: "web", Version: "1.2.3", AppVersion: "7.0"}},
+		Chart: &chart.Chart{
+			Metadata: &chart.Metadata{Name: "web", Version: "1.2.3", AppVersion: "7.0"},
+			// Chart defaults, distinct from the user's Config overrides.
+			Values: map[string]any{"replicas": 1, "imagePullPolicy": "Always"},
+		},
 		Config:    map[string]any{"replicas": 2, "auth": map[string]any{"token": "s3cret"}},
 		Manifest:  "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: web-cm\n---\napiVersion: v1\nkind: Secret\nmetadata:\n  name: web-secret\ndata:\n  password: c3VwZXJzZWNyZXQ=\n",
 	}
@@ -163,6 +167,11 @@ func TestGetReturnsValuesManifestAndHistory(t *testing.T) {
 	if !strings.Contains(detail.Values, "replicas: 2") {
 		t.Fatalf("values = %q", detail.Values)
 	}
+	// Chart defaults ship alongside the overrides so the upgrade dialog can
+	// show them without contacting a repository.
+	if !strings.Contains(detail.ChartValues, "replicas: 1") {
+		t.Fatalf("chartValues = %q", detail.ChartValues)
+	}
 	// Values are user-authored chart input and travel unredacted; only
 	// rendered manifests have Secret data masked.
 	if strings.Contains(detail.Manifest, "c3VwZXJzZWNyZXQ=") || strings.Contains(detail.Manifest, "supersecret") {
@@ -200,7 +209,6 @@ func TestServiceRejectsMissingInputs(t *testing.T) {
 		{"rollback name", RollbackRequest{ContextID: "dev", Namespace: "apps"}},
 		{"rollback revision", RollbackRequest{ContextID: "dev", Namespace: "apps", Name: "web", Revision: -1}},
 		{"upgrade name", UpgradeRequest{ContextID: "dev", Namespace: "apps", RepoURL: "https://example.test", Chart: "web"}},
-		{"upgrade repoUrl", UpgradeRequest{ContextID: "dev", Namespace: "apps", Name: "web", Chart: "web"}},
 		{"upgrade chart", UpgradeRequest{ContextID: "dev", Namespace: "apps", Name: "web", RepoURL: "https://example.test"}},
 		{"upgrade values", UpgradeRequest{ContextID: "dev", Namespace: "apps", Name: "web", RepoURL: "https://example.test", Chart: "web", Values: "{{"}},
 	}
@@ -288,6 +296,53 @@ func TestUpgradeRejectsMissingRelease(t *testing.T) {
 		Name:      "missing",
 		RepoURL:   "https://charts.example.test",
 		Chart:     "web",
+	})
+	var notFoundErr *NotFoundError
+	if err == nil || !errors.As(err, &notFoundErr) {
+		t.Fatalf("error = %v, want NotFoundError", err)
+	}
+}
+
+// An empty repoUrl reuses the chart stored in the release: a values-only
+// upgrade never touches a chart repository, and the chart stays untouched.
+func TestUpgradeWithoutRepoURLReusesStoredChart(t *testing.T) {
+	store := testStorage(t)
+	seed(t, store, chartRelease("web", "apps", 1, release.StatusDeployed))
+	// No locateChart stub: any repository access fails the test.
+	service := testService(t, store)
+
+	response, err := service.Upgrade(context.Background(), UpgradeRequest{
+		ContextID: "dev",
+		Namespace: "apps",
+		Name:      "web",
+		Values:    "replicas: 3\n",
+	})
+	if err != nil {
+		t.Fatalf("Upgrade: %v", err)
+	}
+	if response.Revision != 2 {
+		t.Fatalf("revision = %d, want 2", response.Revision)
+	}
+	latest, err := store.Last("web")
+	if err != nil {
+		t.Fatalf("store.Last: %v", err)
+	}
+	if latest.Chart.Metadata.Version != "1.2.3" {
+		t.Fatalf("chart version = %q, want the stored 1.2.3", latest.Chart.Metadata.Version)
+	}
+	// YAML numbers arrive as float64 through the sigs.k8s.io/yaml JSON round trip.
+	if latest.Config["replicas"] != float64(3) {
+		t.Fatalf("config = %#v, want replicas 3", latest.Config)
+	}
+}
+
+// The reuse path reports a missing release before attempting any upgrade.
+func TestUpgradeWithoutRepoURLRejectsMissingRelease(t *testing.T) {
+	service := testService(t, testStorage(t))
+	_, err := service.Upgrade(context.Background(), UpgradeRequest{
+		ContextID: "dev",
+		Namespace: "apps",
+		Name:      "missing",
 	})
 	var notFoundErr *NotFoundError
 	if err == nil || !errors.As(err, &notFoundErr) {

--- a/core/internal/helm/types.go
+++ b/core/internal/helm/types.go
@@ -64,11 +64,14 @@ type GetRequest struct {
 // the core before they leave it.
 type ReleaseDetail struct {
 	ReleaseSummary
-	Notes     string           `json:"notes,omitempty"`
-	Values    string           `json:"values,omitempty"`
-	Manifest  string           `json:"manifest,omitempty"`
-	Truncated bool             `json:"truncated,omitempty"`
-	History   []ReleaseSummary `json:"history"`
+	Notes    string `json:"notes,omitempty"`
+	Values   string `json:"values,omitempty"`
+	Manifest string `json:"manifest,omitempty"`
+	// ChartValues is the chart's default values.yaml as stored in the release,
+	// so the upgrade dialog can show defaults without contacting a repository.
+	ChartValues string           `json:"chartValues,omitempty"`
+	Truncated   bool             `json:"truncated,omitempty"`
+	History     []ReleaseSummary `json:"history"`
 }
 
 type GetResponse struct {

--- a/core/internal/helm/types.go
+++ b/core/internal/helm/types.go
@@ -85,6 +85,26 @@ type UninstallResponse struct {
 	Info string `json:"info"`
 }
 
+type UpgradeRequest struct {
+	ContextID string `json:"contextId"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	// RepoURL points at the chart repository hosting the chart. It is
+	// required because releases do not record their origin repository, so
+	// there is nothing to default it from.
+	RepoURL string `json:"repoUrl"`
+	Chart   string `json:"chart"`
+	Version string `json:"version,omitempty"`
+	// Values is the complete user values YAML for the new revision. An empty
+	// value resets to the chart defaults, matching helm upgrade without
+	// --reuse-values.
+	Values string `json:"values,omitempty"`
+}
+
+type UpgradeResponse struct {
+	Revision int `json:"revision"`
+}
+
 type RollbackRequest struct {
 	ContextID string `json:"contextId"`
 	Namespace string `json:"namespace"`

--- a/core/internal/helm/types.go
+++ b/core/internal/helm/types.go
@@ -93,8 +93,10 @@ type UpgradeRequest struct {
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
 	// RepoURL points at the chart repository hosting the chart. It is
-	// required because releases do not record their origin repository, so
-	// there is nothing to default it from.
+	// optional: empty reuses the chart stored in the release (values-only
+	// upgrade), since releases do not record their origin repository and
+	// there is nothing to default it from. Set it together with Chart to
+	// pull a fresh chart from a repository.
 	RepoURL string `json:"repoUrl"`
 	Chart   string `json:"chart"`
 	Version string `json:"version,omitempty"`

--- a/core/internal/rpc/server.go
+++ b/core/internal/rpc/server.go
@@ -46,6 +46,7 @@ func NewServer(token string, contexts contextService, resourceService *resources
 	mux.HandleFunc("POST /v1/helm/releases/get", server.getHelmRelease)
 	mux.HandleFunc("POST /v1/helm/releases/uninstall", server.uninstallHelmRelease)
 	mux.HandleFunc("POST /v1/helm/releases/rollback", server.rollbackHelmRelease)
+	mux.HandleFunc("POST /v1/helm/releases/upgrade", server.upgradeHelmRelease)
 	mux.HandleFunc("POST /v1/resources/list", server.listResources)
 	mux.HandleFunc("POST /v1/resources/get", server.getResource)
 	mux.HandleFunc("POST /v1/resources/mutate", server.mutateResource)
@@ -248,6 +249,22 @@ func (s *Server) rollbackHelmRelease(writer http.ResponseWriter, request *http.R
 		return
 	}
 	result, err := s.helm.Rollback(request.Context(), value)
+	if err != nil {
+		writeServiceError(writer, err)
+		return
+	}
+	writeJSON(writer, http.StatusOK, result)
+}
+
+func (s *Server) upgradeHelmRelease(writer http.ResponseWriter, request *http.Request) {
+	var value helm.UpgradeRequest
+	if err := decodeJSON(writer, request, &value); err != nil {
+		return
+	}
+	if rejectInvalid(writer, validateHelmUpgradeRequest(value)) {
+		return
+	}
+	result, err := s.helm.Upgrade(request.Context(), value)
 	if err != nil {
 		writeServiceError(writer, err)
 		return

--- a/core/internal/rpc/server_test.go
+++ b/core/internal/rpc/server_test.go
@@ -203,9 +203,11 @@ func TestServerValidatesHelmRequests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	missingNamespace := performRequest(t, server, http.MethodGet, "/v1/helm/releases?contextId=dev")
-	if missingNamespace.Code != http.StatusBadRequest || !contains(missingNamespace.Body.String(), `"code":"invalid_request"`) {
-		t.Fatalf("status=%d body=%s", missingNamespace.Code, missingNamespace.Body.String())
+	// An empty namespace is now valid (all namespaces); only a missing
+	// context id is rejected at the RPC boundary.
+	missingContext := performRequest(t, server, http.MethodGet, "/v1/helm/releases")
+	if missingContext.Code != http.StatusBadRequest || !contains(missingContext.Body.String(), `"code":"invalid_request"`) {
+		t.Fatalf("status=%d body=%s", missingContext.Code, missingContext.Body.String())
 	}
 
 	missingName := httptest.NewRequest(http.MethodPost, "/v1/helm/releases/get", bytes.NewBufferString(`{

--- a/core/internal/rpc/server_test.go
+++ b/core/internal/rpc/server_test.go
@@ -231,6 +231,19 @@ func TestServerValidatesHelmRequests(t *testing.T) {
 	if response.Code != http.StatusBadRequest || !contains(response.Body.String(), `"code":"invalid_request"`) {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
+
+	missingChart := httptest.NewRequest(http.MethodPost, "/v1/helm/releases/upgrade", bytes.NewBufferString(`{
+		"contextId":"dev",
+		"namespace":"apps",
+		"name":"web",
+		"repoUrl":"https://charts.example.test"
+	}`))
+	missingChart.Header.Set("Authorization", "Bearer token")
+	response = httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, missingChart)
+	if response.Code != http.StatusBadRequest || !contains(response.Body.String(), `"code":"invalid_request"`) {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
 }
 
 func performRequest(t *testing.T, server *Server, method, target string) *httptest.ResponseRecorder {

--- a/core/internal/rpc/validate.go
+++ b/core/internal/rpc/validate.go
@@ -33,6 +33,8 @@ const (
 	maxTailLines            = 100_000
 	maxReplicas             = 1_000_000
 	maxSourcePath           = 4_096
+	maxRepoURL              = 2_048
+	maxChartVersion         = 128
 )
 
 var mutationOperations = map[string]bool{
@@ -320,6 +322,37 @@ func validateHelmRollbackRequest(value helm.RollbackRequest) error {
 		return fmt.Errorf("revision must be between 0 and %d", maxReplicas)
 	}
 	return nil
+}
+
+func validateHelmUpgradeRequest(value helm.UpgradeRequest) error {
+	if err := validateContextID(value.ContextID); err != nil {
+		return err
+	}
+	if err := checkLength("namespace", value.Namespace, maxNamespace); err != nil {
+		return err
+	}
+	if value.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if err := checkLength("name", value.Name, maxName); err != nil {
+		return err
+	}
+	if value.RepoURL == "" {
+		return fmt.Errorf("repoUrl is required")
+	}
+	if err := checkLength("repoUrl", value.RepoURL, maxRepoURL); err != nil {
+		return err
+	}
+	if value.Chart == "" {
+		return fmt.Errorf("chart is required")
+	}
+	if err := checkLength("chart", value.Chart, maxName); err != nil {
+		return err
+	}
+	if err := checkLength("version", value.Version, maxChartVersion); err != nil {
+		return err
+	}
+	return checkLength("values", value.Values, maxYAML)
 }
 
 func checkLength(label, value string, max int) error {

--- a/core/internal/rpc/validate.go
+++ b/core/internal/rpc/validate.go
@@ -273,9 +273,8 @@ func validateHelmListRequest(value helm.ListRequest) error {
 	if err := validateContextID(value.ContextID); err != nil {
 		return err
 	}
-	if value.Namespace == "" {
-		return fmt.Errorf("namespace is required")
-	}
+	// An empty namespace is valid: it means every namespace (helm list -A).
+	// Only non-empty value length is bounded.
 	return checkLength("namespace", value.Namespace, maxNamespace)
 }
 

--- a/core/internal/rpc/validate.go
+++ b/core/internal/rpc/validate.go
@@ -336,17 +336,19 @@ func validateHelmUpgradeRequest(value helm.UpgradeRequest) error {
 	if err := checkLength("name", value.Name, maxName); err != nil {
 		return err
 	}
-	if value.RepoURL == "" {
-		return fmt.Errorf("repoUrl is required")
-	}
+	// repoUrl is optional: an empty value means the upgrade reuses the chart
+	// stored in the release (values-only). chart is only needed — and only
+	// meaningful — when pulling from a repository.
 	if err := checkLength("repoUrl", value.RepoURL, maxRepoURL); err != nil {
 		return err
 	}
-	if value.Chart == "" {
-		return fmt.Errorf("chart is required")
-	}
-	if err := checkLength("chart", value.Chart, maxName); err != nil {
-		return err
+	if value.RepoURL != "" {
+		if value.Chart == "" {
+			return fmt.Errorf("chart is required")
+		}
+		if err := checkLength("chart", value.Chart, maxName); err != nil {
+			return err
+		}
 	}
 	if err := checkLength("version", value.Version, maxChartVersion); err != nil {
 		return err

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 1.58.2
       '@tailwindcss/vite':
         specifier: ^4.3.3
-        version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@tauri-apps/cli':
         specifier: ^2.11.4
         version: 2.11.4
@@ -91,7 +91,10 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
         specifier: ^6.0.5
-        version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      esbuild:
+        specifier: ^0.28.2
+        version: 0.28.2
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -100,10 +103,10 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.2.1
-        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/landing:
     dependencies:
@@ -318,8 +321,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -330,8 +345,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -342,8 +369,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.28.1':
     resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -354,8 +393,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.28.1':
     resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -366,8 +417,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.28.1':
     resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -378,8 +441,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.28.1':
     resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -390,8 +465,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.28.1':
     resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -402,8 +489,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.28.1':
     resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -414,8 +513,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -426,8 +537,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -438,8 +561,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.28.1':
     resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -450,8 +585,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -462,8 +609,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.28.1':
     resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1917,6 +2076,11 @@ packages:
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3549,79 +3713,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
   '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.28.1':
     optional: true
 
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
   '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
   '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.28.1':
     optional: true
 
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.28.1':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
   '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.28.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
   '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@floating-ui/core@1.8.0':
@@ -4187,12 +4429,12 @@ snapshots:
       postcss: 8.5.26
       tailwindcss: 4.3.3
 
-  '@tailwindcss/vite@4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@tanstack/react-virtual@3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -4378,10 +4620,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -4392,13 +4634,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -4773,6 +5015,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
     optional: true
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -6039,7 +6310,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+  vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -6048,16 +6319,16 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.2.0
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.23.1
       yaml: 2.9.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -6074,7 +6345,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## What this adds

An Upgrade action across the core/Tauri/renderer chain: the Helm release detail view opens a form with repository URL, chart, version (prefilled), and a values editor prefilled with the release's current values.

- Submitted values replace the release's values wholesale; clearing them resets to chart defaults, matching `helm upgrade` without `--reuse-values`.
- Charts are located through the user's local Helm settings (repository config and credentials, same as the helm CLI), since releases do not record their origin repository.
- No `--wait`, five-minute timeout; a failed upgrade lands in the existing rollback loop.

## Verification

- Go core: `service_test.go` covers the upgrade path
- Renderer: smoke spec covers the upgrade dialog