### PR TITLE
fix(detail): keep detail view live and in place on refresh

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -323,6 +323,15 @@ export default function App() {
     contexts.setView("contexts");
   }, [contexts, contextId, namespaces, resources, detail, helm]);
 
+  // Refresh targets whatever is on screen: an open detail re-fetches just that
+  // object, because resetting the list scope would close the detail view.
+  const refreshActive = useCallback(() => {
+    if (helmActive) helm.refresh();
+    else if (overviewActive) overview.refresh();
+    else if (detail.selected) void detail.refetch();
+    else resources.refresh();
+  }, [helmActive, helm, overviewActive, overview, detail, resources]);
+
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
@@ -336,11 +345,7 @@ export default function App() {
       }
       if (event.key === "F5") {
         event.preventDefault();
-        if (contexts.view === "workbench") {
-          if (helmActive) helm.refresh();
-          else if (overviewActive) overview.refresh();
-          else resources.refresh();
-        }
+        if (contexts.view === "workbench") refreshActive();
         return;
       }
       if (event.key === "Escape") {
@@ -355,7 +360,7 @@ export default function App() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [detail, paletteOpen, contexts.view, helmActive, helm, overviewActive, overview, resources]);
+  }, [detail, paletteOpen, contexts.view, refreshActive]);
 
   const paletteItems = useMemo(() => {
     const base = buildCommandItems({
@@ -378,9 +383,7 @@ export default function App() {
   const executePaletteCommand = useCallback((action: CommandAction) => {
     switch (action.type) {
       case "refresh":
-        if (helmActive) helm.refresh();
-        else if (overviewActive) overview.refresh();
-        else resources.refresh();
+        refreshActive();
         return;
       case "show-contexts":
         showContextPicker();
@@ -417,7 +420,7 @@ export default function App() {
         void navigator.clipboard.writeText(action.namespace);
         return;
     }
-  }, [overview, overviewActive, helm, helmActive, resources, showContextPicker, connectContext, namespaces, setTheme, resourceGroups, selectKind, openResource]);
+  }, [refreshActive, showContextPicker, connectContext, namespaces, setTheme, resourceGroups, selectKind, openResource]);
 
   useEffect(() => desktop.app.onCommand((command) => {
     if (command === "show-contexts") {
@@ -429,16 +432,14 @@ export default function App() {
       return;
     }
     if (command === "refresh" && contexts.view === "workbench") {
-      if (helmActive) helm.refresh();
-      else if (overviewActive) overview.refresh();
-      else resources.refresh();
+      refreshActive();
       return;
     }
     if (command === "go-back") {
       if (helmActive && helm.selected) helm.clear();
       else if (detail.selected) detail.clear();
     }
-  }), [detail, showContextPicker, contexts.view, resources, overview, overviewActive, helm, helmActive]);
+  }), [detail, showContextPicker, contexts.view, refreshActive, helm, helmActive]);
 
   const searchItems = useMemo(() => searchResultItems(searchResults, paletteQuery), [searchResults, paletteQuery]);
 
@@ -540,8 +541,8 @@ export default function App() {
           query={helmActive || overviewActive ? "" : resources.query}
           onQueryChange={helmActive || overviewActive ? () => undefined : resources.setQuery}
           queryInputRef={searchRef}
-          refreshing={helmActive ? helm.loading : overviewActive ? overview.loading : resources.loading}
-          onRefresh={helmActive ? helm.refresh : overviewActive ? overview.refresh : resources.refresh}
+          refreshing={helmActive ? helm.loading : overviewActive ? overview.loading : detail.selected ? detail.refreshing : resources.loading}
+          onRefresh={refreshActive}
           theme={theme}
           onThemeChange={setTheme}
           onOpenSettings={() => {
@@ -679,7 +680,14 @@ export default function App() {
               events={diagnostics.events}
               related={diagnostics.related}
               onMutate={mutation.mutate}
-              onApplyMutation={mutation.applyPendingMutation}
+              onApplyMutation={async () => {
+                // A successful write re-fetches the object right away instead
+                // of waiting for the list watch (absent in snapshot-only
+                // scopes). Delete removes the object; the list-follow logic
+                // closes the detail when the row disappears.
+                const isDelete = mutation.pendingMutation?.operation === "delete";
+                if (await mutation.applyPendingMutation() && !isDelete) void detail.refetch();
+              }}
               onCancelMutation={mutation.cancelMutation}
               onNavigateRelated={openResource}
               onBack={detail.clear}
@@ -711,7 +719,9 @@ export default function App() {
             preview={mutation.mutationPreview}
             pendingMutation={mutation.pendingMutation}
             onPrepare={(yaml) => mutation.mutate({ operation: "create", yaml })}
-            onApply={mutation.applyPendingMutation}
+            onApply={async () => {
+              await mutation.applyPendingMutation();
+            }}
             onCancel={mutation.cancelMutation}
           />
         </Suspense>

--- a/apps/desktop/src/renderer/hooks/useMutation.ts
+++ b/apps/desktop/src/renderer/hooks/useMutation.ts
@@ -27,7 +27,8 @@ export interface MutationState {
   journal: string[];
   /** Runs the dry-run and stages the pending mutation for review. */
   mutate(request: MutationDraft): Promise<void>;
-  applyPendingMutation(): Promise<void>;
+  /** Applies the staged mutation; resolves true only when the write succeeded. */
+  applyPendingMutation(): Promise<boolean>;
   cancelMutation(): void;
 }
 
@@ -89,7 +90,7 @@ export function useMutation({ contextId, kind, namespace, selected }: MutationOp
   }, [contextId, kind, namespace, selected]);
 
   const applyPendingMutation = useCallback(async () => {
-    if (!pendingMutation) return;
+    if (!pendingMutation) return false;
     setMutationBusy(true);
     setMutationMessage("Applying…");
     try {
@@ -99,8 +100,10 @@ export function useMutation({ contextId, kind, namespace, selected }: MutationOp
       setMutationMessage(applied.changed ? "Applied" : "No change needed");
       setPendingMutation(undefined);
       setMutationPreview("");
+      return true;
     } catch (cause) {
       setMutationMessage(messageOf(cause));
+      return false;
     } finally {
       setMutationBusy(false);
     }

--- a/apps/desktop/src/renderer/hooks/useResourceDetail.ts
+++ b/apps/desktop/src/renderer/hooks/useResourceDetail.ts
@@ -83,24 +83,36 @@ export function useResourceDetail({ contextId, kind, namespace, generation, item
     }
   }, [items, selected]);
 
-  useEffect(() => {
-    if (!selected || !contextId) return;
-    const tag = objectTag(selected);
-    if (detailFor.current === tag) return;
+  // Fetches the object and adopts the returned row. Shared by the follow effect
+  // (on selection change) and refetch (on explicit refresh / applied write).
+  const fetchDetail = useCallback(async (row: ResourceRow) => {
+    if (!contextId) return undefined;
     const request = ++detailRequest.current;
-    setDetail(undefined);
-    setDetailError("");
-    void desktop.resources.get({
-      contextId,
-      resourceKind: kind,
-      namespace: selected.namespace,
-      name: selected.name,
-    }).then((response) => {
-      if (request !== detailRequest.current) return;
+    try {
+      const response = await desktop.resources.get({
+        contextId,
+        resourceKind: kind,
+        namespace: row.namespace,
+        name: row.name,
+      });
+      if (request !== detailRequest.current) return undefined;
       detailFor.current = objectTag(response.row);
       setDetail(response);
-    }).catch((cause) => request === detailRequest.current && setDetailError(messageOf(cause)));
-  }, [contextId, kind, selected]);
+      setDetailError("");
+      return response;
+    } catch (cause) {
+      if (request === detailRequest.current) setDetailError(messageOf(cause));
+      return undefined;
+    }
+  }, [contextId, kind]);
+
+  useEffect(() => {
+    if (!selected || !contextId) return;
+    if (detailFor.current === objectTag(selected)) return;
+    setDetail(undefined);
+    setDetailError("");
+    void fetchDetail(selected);
+  }, [contextId, kind, selected, fetchDetail]);
 
   const select = useCallback((row: ResourceRow) => setSelected(row), []);
   const clear = useCallback(() => {
@@ -113,28 +125,13 @@ export function useResourceDetail({ contextId, kind, namespace, generation, item
   const refetch = useCallback(async () => {
     const current = selectedRef.current;
     if (!current || !contextId) return;
-    const request = ++detailRequest.current;
     setRefreshing(true);
-    try {
-      const response = await desktop.resources.get({
-        contextId,
-        resourceKind: kind,
-        namespace: current.namespace,
-        name: current.name,
-      });
-      if (request !== detailRequest.current) return;
-      detailFor.current = objectTag(response.row);
-      setDetail(response);
-      setDetailError("");
-      // Adopting the fresh row re-fires the fetch effect above; the tag guard
-      // turns that into a no-op instead of a duplicate get.
-      setSelected(response.row);
-    } catch (cause) {
-      if (request === detailRequest.current) setDetailError(messageOf(cause));
-    } finally {
-      if (request === detailRequest.current) setRefreshing(false);
-    }
-  }, [contextId, kind]);
+    // Fetch straight through: the follow effect's tag guard would skip the get
+    // when the snapshot already matches, but an explicit refresh must re-read.
+    const response = await fetchDetail(current);
+    if (response) setSelected(response.row);
+    setRefreshing(false);
+  }, [contextId, fetchDetail]);
 
   return { selected, detail, detailError, refreshing, select, clear, refetch };
 }

--- a/apps/desktop/src/renderer/hooks/useResourceDetail.ts
+++ b/apps/desktop/src/renderer/hooks/useResourceDetail.ts
@@ -16,8 +16,31 @@ export interface ResourceDetailState {
   selected?: ResourceRow;
   detail?: ResourceGetResponse;
   detailError: string;
+  /** True while an explicit object refresh is in flight. */
+  refreshing: boolean;
   select(row: ResourceRow): void;
   clear(): void;
+  /**
+   * Re-gets the open object and adopts the returned row, so a refresh (or an
+   * applied mutation) updates the vitals and YAML without waiting for the
+   * list watch — which snapshot-only scopes do not have.
+   */
+  refetch(): Promise<void>;
+}
+
+/** Identity tag of the object a fetched detail belongs to. */
+function objectTag(row: ResourceRow): string {
+  return `${row.uid || `${row.kind}:${row.namespace}/${row.name}`}@${row.resourceVersion}`;
+}
+
+/**
+ * Kubernetes resource versions are monotonic (the watch pipeline relies on
+ * this), so a numerically newer version always wins. Non-numeric values fall
+ * back to inequality — the old adopt-on-any-change behavior.
+ */
+function isNewerResourceVersion(candidate: string, current: string): boolean {
+  if (/^\d+$/.test(candidate) && /^\d+$/.test(current)) return BigInt(candidate) > BigInt(current);
+  return candidate !== current;
 }
 
 /**
@@ -29,13 +52,20 @@ export function useResourceDetail({ contextId, kind, namespace, generation, item
   const [selected, setSelected] = useState<ResourceRow>();
   const [detail, setDetail] = useState<ResourceGetResponse>();
   const [detailError, setDetailError] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
   const detailRequest = useRef(0);
+  /** Tag of the object the current `detail` was fetched for; skips duplicate gets. */
+  const detailFor = useRef("");
+  const selectedRef = useRef<ResourceRow | undefined>(undefined);
+  selectedRef.current = selected;
 
   useEffect(() => {
     ++detailRequest.current;
+    detailFor.current = "";
     setSelected(undefined);
     setDetail(undefined);
     setDetailError("");
+    setRefreshing(false);
   }, [contextId, kind, namespace, generation]);
 
   useEffect(() => {
@@ -43,15 +73,20 @@ export function useResourceDetail({ contextId, kind, namespace, generation, item
     const next = items.find((row) => (row.uid || `${row.kind}:${row.namespace}/${row.name}`)
       === (selected.uid || `${selected.kind}:${selected.namespace}/${selected.name}`));
     if (!next) {
+      detailFor.current = "";
       setSelected(undefined);
       setDetail(undefined);
-    } else if (next.resourceVersion !== selected.resourceVersion) {
+    } else if (isNewerResourceVersion(next.resourceVersion, selected.resourceVersion)) {
+      // Never downgrade: an explicit refetch adopts the row the get returned,
+      // which a stale list snapshot (or a lagging watch) has not caught up with.
       setSelected(next);
     }
   }, [items, selected]);
 
   useEffect(() => {
     if (!selected || !contextId) return;
+    const tag = objectTag(selected);
+    if (detailFor.current === tag) return;
     const request = ++detailRequest.current;
     setDetail(undefined);
     setDetailError("");
@@ -61,16 +96,45 @@ export function useResourceDetail({ contextId, kind, namespace, generation, item
       namespace: selected.namespace,
       name: selected.name,
     }).then((response) => {
-      if (request === detailRequest.current) setDetail(response);
+      if (request !== detailRequest.current) return;
+      detailFor.current = objectTag(response.row);
+      setDetail(response);
     }).catch((cause) => request === detailRequest.current && setDetailError(messageOf(cause)));
   }, [contextId, kind, selected]);
 
   const select = useCallback((row: ResourceRow) => setSelected(row), []);
   const clear = useCallback(() => {
+    detailFor.current = "";
     setSelected(undefined);
     setDetail(undefined);
     setDetailError("");
   }, []);
 
-  return { selected, detail, detailError, select, clear };
+  const refetch = useCallback(async () => {
+    const current = selectedRef.current;
+    if (!current || !contextId) return;
+    const request = ++detailRequest.current;
+    setRefreshing(true);
+    try {
+      const response = await desktop.resources.get({
+        contextId,
+        resourceKind: kind,
+        namespace: current.namespace,
+        name: current.name,
+      });
+      if (request !== detailRequest.current) return;
+      detailFor.current = objectTag(response.row);
+      setDetail(response);
+      setDetailError("");
+      // Adopting the fresh row re-fires the fetch effect above; the tag guard
+      // turns that into a no-op instead of a duplicate get.
+      setSelected(response.row);
+    } catch (cause) {
+      if (request === detailRequest.current) setDetailError(messageOf(cause));
+    } finally {
+      if (request === detailRequest.current) setRefreshing(false);
+    }
+  }, [contextId, kind]);
+
+  return { selected, detail, detailError, refreshing, select, clear, refetch };
 }

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -76,6 +76,10 @@ const MOCK_DESKTOP_API = `
     };
   };
 
+  // Records the last applied scale so the object get reflects the write — the
+  // watch fixture only ever ships the rv-1000 snapshot, like a lagging stream.
+  let scaledReplicas = null;
+
   // A realistic Deployment object: selector, strategy, conditions, and
   // annotations feed the overview's structured sections and the pods scope.
   const deploymentYaml = (name) => [
@@ -229,12 +233,18 @@ const MOCK_DESKTOP_API = `
     },
     resources: {
       list: async (request) => pageOf(request),
-      get: async (request) => ({
-        row: row(request.resourceKind, 0, request.resourceKind.namespaced),
-        yaml: request.resourceKind.kind === "Deployment"
+      get: async (request) => {
+        const fresh = row(request.resourceKind, 0, request.resourceKind.namespaced);
+        let yaml = request.resourceKind.kind === "Deployment"
           ? deploymentYaml(request.name)
-          : "apiVersion: apps/v1\\nkind: " + request.resourceKind.kind + "\\nmetadata:\\n  name: " + request.name + "\\n",
-      }),
+          : "apiVersion: apps/v1\\nkind: " + request.resourceKind.kind + "\\nmetadata:\\n  name: " + request.name + "\\n";
+        if (scaledReplicas !== null && request.resourceKind.kind === "Deployment") {
+          fresh.desired = scaledReplicas;
+          fresh.resourceVersion = "1002";
+          yaml = yaml.replace("  replicas: 2", "  replicas: " + scaledReplicas);
+        }
+        return { row: fresh, yaml };
+      },
       events: async () => [
         { name: "event-1", namespace: "default", reason: "Scheduled", message: "Successfully assigned", type: "Normal", count: 1, lastTimestamp: "2026-08-01T00:00:00Z" },
       ],
@@ -287,6 +297,9 @@ const MOCK_DESKTOP_API = `
         // is rejected.
         if (!request.dryRun && request.resourceVersion && request.resourceVersion !== "1001") {
           throw new Error("resource version conflict: expected " + request.resourceVersion + ", got 1001");
+        }
+        if (!request.dryRun && request.operation === "scale") {
+          scaledReplicas = request.replicas;
         }
         // Mirror the API server: a scale dry-run echoes the would-be object,
         // including server-managed bumps (generation) the review diff filters out.
@@ -589,6 +602,41 @@ test("resource detail opens and preserves layout", async ({ page }) => {
   await expect(actions.getByTestId("delete-resource")).toBeVisible();
   await expectNoOverflow(page, "detail 1280x800");
   await screenshot(page, "detail-1280");
+  expect(failures).toEqual([]);
+});
+
+test("detail reflects an applied scale and survives manual refresh", async ({ page }) => {
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await connectToDev(page);
+
+  const grid = page.getByRole("grid", { name: "Resources" });
+  const firstRow = grid.getByRole("row").nth(1);
+  await expect(firstRow).toContainText("deployments-0", { timeout: 15_000 });
+  await firstRow.click();
+
+  const detail = page.getByTestId("resource-detail-view");
+  await expect(detail).toBeVisible({ timeout: 15_000 });
+  const vitals = page.getByTestId("resource-vitals");
+  await expect(vitals).toContainText("2/2");
+
+  // Scale 2 → 3 through the dry-run review. The mock's list watch never ships
+  // the write (rv-1000 snapshot only), so the update must come from the
+  // post-apply refetch, and the stale snapshot must not downgrade it back.
+  await page.getByTestId("resource-action-scale").click();
+  await page.getByLabel("Desired replicas").fill("3");
+  await page.getByTestId("operation-prepare-dry-run").click();
+  await page.getByTestId("mutation-apply").click();
+  await expect(vitals).toContainText("2/3", { timeout: 15_000 });
+
+  // A manual refresh re-fetches the object in place instead of dropping back
+  // to the resource list.
+  await page.keyboard.press("F5");
+  await expect(detail).toBeVisible();
+  await expect(vitals).toContainText("2/3");
+  await expectNoOverflow(page, "detail after scale and refresh 1280x800");
+  await screenshot(page, "detail-scale-refresh-1280");
   expect(failures).toEqual([]);
 });
 

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -234,7 +234,10 @@ const MOCK_DESKTOP_API = `
     resources: {
       list: async (request) => pageOf(request),
       get: async (request) => {
-        const fresh = row(request.resourceKind, 0, request.resourceKind.namespaced);
+        // The list may open any row, not just index 0; derive the index from
+        // the requested name so the returned uid matches the selected row.
+        const index = Number(request.name.slice(request.resourceKind.resource.length + 1)) || 0;
+        const fresh = row(request.resourceKind, index, request.resourceKind.namespaced);
         let yaml = request.resourceKind.kind === "Deployment"
           ? deploymentYaml(request.name)
           : "apiVersion: apps/v1\\nkind: " + request.resourceKind.kind + "\\nmetadata:\\n  name: " + request.name + "\\n";


### PR DESCRIPTION
Closes #7

## Problem

After applying a scale (or any write) from a resource's detail page, the replica count stays stale, and a manual refresh ejects the user back to the resource list. Two root causes:

1. Detail updates rely entirely on the list watch stream; a successful apply never re-fetches the object. In snapshot-only scopes (e.g. All namespaces) or when the watch silently dies, the detail never updates.
2. A manual refresh bumps the list `generation`, which closes the selection (the "close stale selections" behavior); the refresh also empties the list items, so the follow logic closes the detail too.

## Fix

- `useResourceDetail` gains `refetch()`: re-gets the open object and adopts the returned row, so vitals and YAML update immediately without waiting on the list watch.
- The list-follow effect now only replaces the selected row when the incoming **resourceVersion is newer** (the watch pipeline already assumes monotonic versions; non-numeric versions fall back to the old adopt-on-any-change behavior), so a stale snapshot can never downgrade a freshly refetched row.
- `applyPendingMutation` reports success; a successful non-delete apply triggers `refetch()`.
- The three refresh entry points (toolbar, F5, command palette) are unified into `refreshActive`: with a detail open it re-fetches just that object instead of bumping the generation, so the detail stays open.
- New Playwright regression test: against a watch fixture that only ever ships the stale snapshot, drive scale 2→3, assert vitals become 2/3, press F5, assert the detail stays open.

## Verification

- `pnpm typecheck` / `pnpm test` (86 passing) / `pnpm build`
- `pnpm --dir apps/desktop smoke:visual`: 20/20 passing, including the new screenshot and overflow assertions

No Go / Rust changes.

## Known boundary

If the object is deleted between the write and the refetch, the detail shows an error instead of auto-navigating back to the list.