### PR TITLE
fix(ui): show overview errors instead of loading forever

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -4063,6 +4063,27 @@ button.overview-card:focus-visible {
   font-size: 12px;
 }
 
+.overview-error:has(.overview-error-detail) {
+  align-items: flex-start;
+}
+
+.overview-error:has(.overview-error-detail) > svg {
+  margin-top: 1px;
+}
+
+.overview-error-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.overview-error-detail {
+  color: color-mix(in srgb, var(--failed) 70%, var(--faint));
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+
 .overview-skeleton {
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/renderer/views/OverviewView.tsx
+++ b/apps/desktop/src/renderer/views/OverviewView.tsx
@@ -49,6 +49,10 @@ export function OverviewView({
   onNavigate,
 }: OverviewProps) {
   const skeleton = loading || !overview;
+  // RBAC-denied clusters (e.g. namespace-scoped sealos accounts) fail with the
+  // Kubernetes "is forbidden" wording; surface that as a permission message
+  // instead of the raw API error.
+  const forbidden = /forbidden/i.test(error);
 
   return (
     <section aria-label="Cluster overview" className="overview-pane" data-testid="overview-view">
@@ -68,13 +72,20 @@ export function OverviewView({
       </div>
 
       <div className="overview-scroll">
-        {skeleton ? (
-          <OverviewSkeleton />
-        ) : error ? (
-          <div className="overview-error" role="alert">
+        {error ? (
+          <div className="overview-error" role="alert" data-testid="overview-error">
             <AlertTriangle aria-hidden="true" className="size-4" />
-            <span>{error}</span>
+            <span className="overview-error-body">
+              <span>
+                {forbidden
+                  ? "This account doesn't have permission to view the cluster overview. It requires cluster-scoped read access, which namespace-scoped accounts (like sealos) don't have."
+                  : error}
+              </span>
+              {forbidden ? <span className="overview-error-detail">{error}</span> : null}
+            </span>
           </div>
+        ) : skeleton ? (
+          <OverviewSkeleton />
         ) : (
           <>
             <StatCards overview={overview} onNavigate={onNavigate} />

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -491,6 +491,39 @@ test("overview is a sidebar pane and swaps back to the resource table", async ({
   expect(failures).toEqual([]);
 });
 
+test("overview shows a permission error instead of loading forever", async ({ page }) => {
+  // Namespace-scoped accounts (e.g. sealos) get RBAC-forbidden on the
+  // cluster-scoped overview lists; the pane must say so, not hang on skeletons.
+  await page.addInitScript(() => {
+    const desktop = (window as unknown as { __ASTER_DESKTOP__?: { overview: { get(): Promise<unknown> } } }).__ASTER_DESKTOP__;
+    if (desktop) {
+      desktop.overview.get = async () => {
+        throw new Error('nodes is forbidden: User "cyhipdvv" cannot list resource "nodes" in API group "" at the cluster scope');
+      };
+    }
+  });
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await connectToDev(page);
+
+  await page.getByTestId("source-list-overview").click();
+  const overview = page.getByTestId("overview-view");
+  await expect(overview).toBeVisible();
+
+  const error = overview.getByTestId("overview-error");
+  await expect(error).toBeVisible();
+  await expect(error).toContainText("doesn't have permission");
+  // The raw API error stays available as the detail line.
+  await expect(error).toContainText("nodes is forbidden");
+  // No skeleton lingers once the failure is known.
+  await expect(overview.locator(".overview-skeleton")).toHaveCount(0);
+
+  await expectNoOverflow(page, "overview forbidden 1280x800");
+  await screenshot(page, "overview-forbidden-1280");
+  expect(failures).toEqual([]);
+});
+
 test("custom resources nest by API domain and scroll with the sidebar", async ({ page }) => {
   const failures = collectFailures(page);
   await page.setViewportSize({ width: 1280, height: 800 });


### PR DESCRIPTION
## Problem

With a low-permission kubeconfig (e.g. a namespace-scoped sealos account), the cluster-scoped lists behind the Overview page return 403, but the UI showed loading skeletons forever.

Root cause: in `OverviewView`, `skeleton = loading || !overview` made the error branch unreachable when the very first fetch failed — `overview` stays `undefined`, so the skeleton branch always won.

## Fix

- Render the error state ahead of the skeleton, so an initial-fetch failure surfaces immediately.
- Word RBAC-forbidden failures as a permission message ("This account doesn't have permission to view the cluster overview…"), keeping the raw Kubernetes error as a smaller detail line.
- Add a renderer smoke test that mocks a 403 and asserts the error shows and no skeleton lingers.

## Verification

- `pnpm typecheck`, `pnpm test`
- `pnpm --dir apps/desktop smoke:visual` — 20/20 passed, including the new forbidden case; screenshot inspected for layout/overflow.

Closes #3