### PR TITLE
fix(detail): return to the resource list after a successful delete

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -682,10 +682,18 @@ export default function App() {
               onApplyMutation={async () => {
                 // A successful write re-fetches the object right away instead
                 // of waiting for the list watch (absent in snapshot-only
-                // scopes). Delete removes the object; the list-follow logic
-                // closes the detail when the row disappears.
+                // scopes). Delete instead closes the detail and refreshes the
+                // list: snapshot-only scopes get no watch delta, so the row
+                // would never disappear on its own.
                 const isDelete = mutation.pendingMutation?.operation === "delete";
-                if (await mutation.applyPendingMutation() && !isDelete) void detail.refetch();
+                if (await mutation.applyPendingMutation()) {
+                  if (isDelete) {
+                    detail.clear();
+                    resources.refresh();
+                  } else {
+                    void detail.refetch();
+                  }
+                }
               }}
               onCancelMutation={mutation.cancelMutation}
               onNavigateRelated={openResource}

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -653,6 +653,46 @@ test("resource detail opens and preserves layout", async ({ page }) => {
   expect(failures).toEqual([]);
 });
 
+test("YAML editor scrolls long lines horizontally instead of wrapping", async ({ page }) => {
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await connectToDev(page);
+
+  const grid = page.getByRole("grid", { name: "Resources" });
+  const firstRow = grid.getByRole("row").nth(1);
+  await expect(firstRow).toContainText("deployments-0", { timeout: 15_000 });
+  await firstRow.click();
+
+  const detail = page.getByTestId("resource-detail-view");
+  await expect(detail).toBeVisible({ timeout: 15_000 });
+  await detail.getByRole("tab", { name: "YAML" }).click();
+  await detail.getByTestId("yaml-edit").click();
+
+  const editor = detail.getByTestId("resource-yaml-editor");
+  await expect(editor).toBeVisible();
+  await expect(editor).toHaveAttribute("wrap", "off");
+
+  // The fixture fits the editor width, so nothing scrolls yet; a long
+  // unbroken line (like kubectl's last-applied-configuration annotation)
+  // must overflow horizontally, staying one visual line that scrolls.
+  expect(await editor.evaluate((el) => el.scrollWidth <= el.clientWidth)).toBe(true);
+  const longLine =
+    "    kubectl.kubernetes.io/last-applied-configuration: " +
+    '{"apiVersion":"apps/v1","kind":"Deployment","spec":{"replicas":2,"template":{"spec":{"containers":[{"name":"web","image":"nginx:1.27"}]}}}}';
+  await editor.fill((await editor.inputValue()) + "\n" + longLine);
+  expect(await editor.evaluate((el) => el.scrollWidth > el.clientWidth)).toBe(true);
+
+  // Park the scroll at the long line so the screenshot shows it intact.
+  await editor.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+    el.scrollLeft = 0;
+  });
+  await expectNoOverflow(page, "yaml editor long line 1280x800");
+  await screenshot(page, "detail-yaml-editor-nowrap-1280");
+  expect(failures).toEqual([]);
+});
+
 test("detail reflects an applied scale and survives manual refresh", async ({ page }) => {
   const failures = collectFailures(page);
   await page.setViewportSize({ width: 1280, height: 800 });


### PR DESCRIPTION
## Problem

After deleting a Service (issue #4), the detail view stayed open instead of returning to the resource list.

Root cause: the detail view only closed when the deleted row disappeared from the list via a watch delta. Namespaced kinds viewed across all namespaces use a snapshot-only list with no live watch (`useResourceList.ts` `watchEnabled`), so the row never disappeared and the deleted object stayed open forever.

## Fix

After a successful delete from the detail view, close the detail and refresh the list explicitly (`detail.clear()` + `resources.refresh()`) instead of waiting for the row to disappear. This matches the existing bulk-delete flow and behaves deterministically in both watch and snapshot modes.

`isDelete` is captured before apply because `applyPendingMutation` clears `pendingMutation` on success.

Closes #4

## Verification

- `pnpm typecheck` ✅
- `pnpm test` — 86 passed ✅
- `pnpm --dir apps/desktop smoke:visual` — 25 passed ✅