### PR TITLE
feat(picker): show cluster reachability status in the context list

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -40,6 +40,11 @@ pub async fn contexts_list(state: State<'_, AppState>) -> Result<Value, String> 
 }
 
 #[tauri::command]
+pub async fn contexts_health(state: State<'_, AppState>, request: Value) -> Result<Value, String> {
+    state.core.post("/v1/contexts/health", request).await
+}
+
+#[tauri::command]
 pub async fn sources_report(state: State<'_, AppState>) -> Result<Value, String> {
     state.core.get("/v1/sources").await
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -100,6 +100,7 @@ pub fn run() {
             commands::app_open_external,
             commands::core_status,
             commands::contexts_list,
+            commands::contexts_health,
             commands::sources_report,
             commands::sources_rename,
             commands::namespaces_list,

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -493,6 +493,8 @@ export default function App() {
         layout={contexts.contextLayout}
         loading={contexts.contextsLoading}
         error={contexts.contextsError}
+        health={contexts.contextHealth}
+        healthProbing={contexts.healthProbing}
         onQueryChange={contexts.setContextQuery}
         onLayoutChange={contexts.setContextLayout}
         onSelect={contexts.setContextChoice}

--- a/apps/desktop/src/renderer/hooks/useContexts.ts
+++ b/apps/desktop/src/renderer/hooks/useContexts.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import type { ContextInfo, CoreStatus } from "../../shared/types";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ContextHealthMap, ContextInfo, CoreStatus } from "../../shared/types";
 import { filterContexts, retainedContextChoice, type ContextLayout } from "../lib/context-picker";
 import { messageOf } from "../lib/format";
 import { desktop } from "../lib/desktop";
@@ -17,6 +17,10 @@ export interface ContextsState {
   contextLayout: ContextLayout;
   contextsLoading: boolean;
   contextsError: string;
+  /** Per-context reachability, filled in asynchronously after each list load. */
+  contextHealth: ContextHealthMap;
+  /** True while a health probe round is in flight (rows show a checking dot). */
+  healthProbing: boolean;
   activeContext?: ContextInfo;
   chosenContext?: ContextInfo;
   visibleContexts: ContextInfo[];
@@ -47,12 +51,19 @@ export function useContexts(core: CoreStatus): ContextsState {
   const [contextLayout, setContextLayout] = useState<ContextLayout>("list");
   const [contextsLoading, setContextsLoading] = useState(false);
   const [contextsError, setContextsError] = useState("");
+  const [contextHealth, setContextHealth] = useState<ContextHealthMap>({});
+  const [healthProbing, setHealthProbing] = useState(false);
+  // Guards against a slow list/probe round overwriting a newer one (Refresh
+  // while a previous probe is still waiting on a dead cluster).
+  const loadSeq = useRef(0);
 
   const loadContexts = useCallback(async () => {
     setContextsLoading(true);
     setContextsError("");
+    const seq = ++loadSeq.current;
     try {
       const next = await desktop.contexts.list();
+      if (loadSeq.current !== seq) return;
       setContexts(next);
       setContextChoice((current) => {
         // Preselect the last connected context across launches; connecting
@@ -64,10 +75,34 @@ export function useContexts(core: CoreStatus): ContextsState {
         }
         return preferred;
       });
+      // The list is usable now; probes below must not hold the loading
+      // spinner (a dead cluster waits out its probe timeout).
+      setContextsLoading(false);
+      // Reachability probes are advisory and run after the list renders.
+      // Contexts with a static config error are skipped — they cannot dial.
+      const probeIds = next.filter((item) => !item.error).map((item) => item.id);
+      setContextHealth({});
+      if (!probeIds.length) {
+        setHealthProbing(false);
+        return;
+      }
+      setHealthProbing(true);
+      try {
+        const health = await desktop.contexts.health(probeIds);
+        if (loadSeq.current !== seq) return;
+        setContextHealth(Object.fromEntries(health.map((entry) => [entry.id, entry])));
+      } catch {
+        // A failed probe round just clears the checking dots; the list itself
+        // is already usable, so this stays silent.
+        if (loadSeq.current === seq) setContextHealth({});
+      } finally {
+        if (loadSeq.current === seq) setHealthProbing(false);
+      }
     } catch (cause) {
+      if (loadSeq.current !== seq) return;
       setContextsError(messageOf(cause));
     } finally {
-      setContextsLoading(false);
+      if (loadSeq.current === seq) setContextsLoading(false);
     }
   }, []);
 
@@ -89,6 +124,8 @@ export function useContexts(core: CoreStatus): ContextsState {
     contextLayout,
     contextsLoading,
     contextsError,
+    contextHealth,
+    healthProbing,
     activeContext,
     chosenContext,
     visibleContexts,

--- a/apps/desktop/src/renderer/lib/desktop-tauri.ts
+++ b/apps/desktop/src/renderer/lib/desktop-tauri.ts
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import type {
   AppCommand,
   AsterSettings,
+  ContextHealth,
   ContextInfo,
   CoreStatus,
   DesktopApi,
@@ -105,6 +106,10 @@ export function createTauriDesktopApi(): DesktopApi {
       list: async () => {
         const value = await invoke<{ contexts: ContextInfo[] }>("contexts_list");
         return value.contexts;
+      },
+      health: async (contextIds) => {
+        const value = await invoke<{ health: ContextHealth[] }>("contexts_health", { request: { contextIds } });
+        return value.health;
       },
       sourcesReport: () => invoke<SourcesReport>("sources_report"),
       renameConflict: async (request) => {

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -540,18 +540,37 @@ h2 {
   white-space: nowrap;
 }
 
-.context-health {
+.context-card-icon {
+  position: relative;
   display: inline-flex;
   flex-shrink: 0;
+}
+
+.context-health {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  display: inline-flex;
   align-items: center;
   cursor: default;
 }
 
 .context-health-dot {
   display: block;
-  width: 8px;
-  height: 8px;
+  width: 9px;
+  height: 9px;
   border-radius: 50%;
+  /* Ring in the row background keeps the dot legible over the tinted icon. */
+  box-shadow: 0 0 0 2px var(--surface);
+  transition: box-shadow 120ms ease;
+}
+
+.context-card:hover:not(:disabled) .context-health-dot {
+  box-shadow: 0 0 0 2px var(--surface-hover);
+}
+
+.context-card[data-selected="true"] .context-health-dot {
+  box-shadow: 0 0 0 2px var(--selection);
 }
 
 .context-health[data-state="ok"] .context-health-dot {

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -548,29 +548,31 @@ h2 {
 
 .context-health {
   position: absolute;
-  top: -2px;
-  right: -2px;
+  top: 0;
+  right: 0;
+  transform: translate(35%, -35%);
   display: inline-flex;
   align-items: center;
   cursor: default;
+  pointer-events: auto;
 }
 
 .context-health-dot {
   display: block;
-  width: 9px;
-  height: 9px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   /* Ring in the row background keeps the dot legible over the tinted icon. */
-  box-shadow: 0 0 0 2px var(--surface);
+  box-shadow: 0 0 0 1.5px var(--surface);
   transition: box-shadow 120ms ease;
 }
 
 .context-card:hover:not(:disabled) .context-health-dot {
-  box-shadow: 0 0 0 2px var(--surface-hover);
+  box-shadow: 0 0 0 1.5px var(--surface-hover);
 }
 
 .context-card[data-selected="true"] .context-health-dot {
-  box-shadow: 0 0 0 2px var(--selection);
+  box-shadow: 0 0 0 1.5px var(--selection);
 }
 
 .context-health[data-state="ok"] .context-health-dot {

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -540,6 +540,50 @@ h2 {
   white-space: nowrap;
 }
 
+.context-health {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  cursor: default;
+}
+
+.context-health-dot {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.context-health[data-state="ok"] .context-health-dot {
+  background: var(--healthy);
+}
+
+.context-health[data-state="error"] .context-health-dot {
+  background: var(--failed);
+}
+
+.context-health[data-state="checking"] .context-health-dot {
+  background: var(--text-secondary);
+  opacity: 0.5;
+  animation: context-health-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes context-health-pulse {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .context-health[data-state="checking"] .context-health-dot {
+    animation: none;
+  }
+}
+
 .context-conflict-warning {
   display: inline-flex;
   flex-shrink: 0;

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -548,9 +548,8 @@ h2 {
 
 .context-health {
   position: absolute;
-  top: 0;
-  right: 0;
-  transform: translate(35%, -35%);
+  top: -3px;
+  right: -3px;
   display: inline-flex;
   align-items: center;
   cursor: default;

--- a/apps/desktop/src/renderer/views/ContextPicker.tsx
+++ b/apps/desktop/src/renderer/views/ContextPicker.tsx
@@ -431,33 +431,35 @@ function ContextPicker({
                     onDoubleClick={() => connect(context)}
                     onKeyDown={(event) => handleOptionKeyDown(event, context)}
                   >
-                    <span className="kubernetes-mark" aria-hidden="true">
-                      <Boxes />
+                    <span className="context-card-icon">
+                      <span className="kubernetes-mark" aria-hidden="true">
+                        <Boxes />
+                      </span>
+                      {healthState && (
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <span
+                                className="context-health"
+                                data-state={healthState}
+                                data-testid={`context-health-${context.id}`}
+                                aria-label={healthLabel}
+                                onClick={(event) => event.stopPropagation()}
+                                onDoubleClick={(event) => event.stopPropagation()}
+                              />
+                            }
+                          >
+                            <span className="context-health-dot" aria-hidden="true" />
+                          </TooltipTrigger>
+                          <TooltipContent className="block max-w-sm leading-relaxed break-all">
+                            {healthLabel}
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
                     </span>
                     <span className="context-card-copy">
                       <strong>{context.name}</strong>
                       <span className="context-card-sub">
-                        {healthState && (
-                          <Tooltip>
-                            <TooltipTrigger
-                              render={
-                                <span
-                                  className="context-health"
-                                  data-state={healthState}
-                                  data-testid={`context-health-${context.id}`}
-                                  aria-label={healthLabel}
-                                  onClick={(event) => event.stopPropagation()}
-                                  onDoubleClick={(event) => event.stopPropagation()}
-                                />
-                              }
-                            >
-                              <span className="context-health-dot" aria-hidden="true" />
-                            </TooltipTrigger>
-                            <TooltipContent className="block max-w-sm leading-relaxed break-all">
-                              {healthLabel}
-                            </TooltipContent>
-                          </Tooltip>
-                        )}
                         <span className="context-card-cluster">
                           {context.cluster || "Kubernetes cluster"}
                         </span>

--- a/apps/desktop/src/renderer/views/ContextPicker.tsx
+++ b/apps/desktop/src/renderer/views/ContextPicker.tsx
@@ -14,7 +14,7 @@ import {
 import { AsterMark } from "../components/AsterMark";
 import { useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 
-import type { ContextInfo, CoreStatus, RenameConflictRequest } from "../../shared/types";
+import type { ContextHealthMap, ContextInfo, CoreStatus, RenameConflictRequest } from "../../shared/types";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -48,6 +48,9 @@ interface ContextPickerProps {
   layout: ContextLayout;
   loading: boolean;
   error: string;
+  /** Per-context reachability; a missing entry means unknown or still probing. */
+  health: ContextHealthMap;
+  healthProbing: boolean;
   onQueryChange(value: string): void;
   onLayoutChange(value: ContextLayout): void;
   onSelect(value: string): void;
@@ -67,6 +70,8 @@ function ContextPicker({
   layout,
   loading,
   error,
+  health,
+  healthProbing,
   onQueryChange,
   onLayoutChange,
   onSelect,
@@ -388,6 +393,25 @@ function ContextPicker({
                 const isSelected = context.id === selectedId;
                 const isTabStop = isSelected || (!selected && context.id === firstSelectableId);
                 const hasConflicts = Boolean(context.conflicts?.length);
+                const healthEntry = health[context.id];
+                // Static config errors already render below the name; the dot
+                // is only for dialable contexts. A missing entry is "checking"
+                // while a probe round runs, otherwise the row shows nothing.
+                const healthState = context.error
+                  ? null
+                  : healthEntry
+                    ? healthEntry.status
+                    : healthProbing
+                      ? "checking"
+                      : null;
+                const healthLabel =
+                  healthState === "ok"
+                    ? `Reachable${healthEntry?.version ? ` · ${healthEntry.version}` : ""}${
+                        healthEntry?.latencyMs != null ? ` · ${healthEntry.latencyMs} ms` : ""
+                      }`
+                    : healthState === "error"
+                      ? `Unreachable${healthEntry?.message ? `: ${healthEntry.message}` : ""}`
+                      : "Checking reachability…";
 
                 return (
                   <Button
@@ -413,6 +437,27 @@ function ContextPicker({
                     <span className="context-card-copy">
                       <strong>{context.name}</strong>
                       <span className="context-card-sub">
+                        {healthState && (
+                          <Tooltip>
+                            <TooltipTrigger
+                              render={
+                                <span
+                                  className="context-health"
+                                  data-state={healthState}
+                                  data-testid={`context-health-${context.id}`}
+                                  aria-label={healthLabel}
+                                  onClick={(event) => event.stopPropagation()}
+                                  onDoubleClick={(event) => event.stopPropagation()}
+                                />
+                              }
+                            >
+                              <span className="context-health-dot" aria-hidden="true" />
+                            </TooltipTrigger>
+                            <TooltipContent className="block max-w-sm leading-relaxed break-all">
+                              {healthLabel}
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
                         <span className="context-card-cluster">
                           {context.cluster || "Kubernetes cluster"}
                         </span>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -44,6 +44,22 @@ export interface ContextInfo {
   error?: string;
 }
 
+/**
+ * Reachability probe result for one context, from the core's
+ * POST /v1/contexts/health. Advisory only: an "error" status never blocks
+ * connecting, since a cluster can reject /version yet serve real requests.
+ */
+export interface ContextHealth {
+  id: string;
+  status: "ok" | "error";
+  latencyMs?: number;
+  version?: string;
+  message?: string;
+}
+
+/** Renderer-side health for a row: absent until its probe resolves. */
+export type ContextHealthMap = Record<string, ContextHealth>;
+
 export interface AsterSettings {
   kubeconfigSources: string[];
   /**
@@ -485,6 +501,11 @@ export interface DesktopApi {
   };
   contexts: {
     list(): Promise<ContextInfo[]>;
+    /**
+     * Probes API server reachability for the given contexts. Resolves after
+     * the slowest probe (bounded per-context by the core's probe timeout).
+     */
+    health(contextIds: string[]): Promise<ContextHealth[]>;
     sourcesReport(): Promise<SourcesReport>;
     /**
      * Resolves a kubeconfig name collision by renaming the colliding entry

--- a/apps/desktop/tests/live/shim.ts
+++ b/apps/desktop/tests/live/shim.ts
@@ -119,6 +119,7 @@ const api: DesktopApi = {
   },
   contexts: {
     list: async () => (await coreGet("/v1/contexts")).contexts ?? [],
+    health: async (contextIds) => (await corePost("/v1/contexts/health", { contextIds })).health ?? [],
     sourcesReport: () => coreGet("/v1/sources"),
     renameConflict: async (request) => { await corePost("/v1/sources/rename", request); },
   },

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -150,6 +150,10 @@ const MOCK_DESKTOP_API = `
     },
     contexts: {
       list: async () => contexts,
+      // prod is unreachable so both dot states show up in the picker tests.
+      health: async (ids) => ids.map((id) => id === "prod"
+        ? { id, status: "error", message: "dial tcp 10.0.0.2:443: i/o timeout" }
+        : { id, status: "ok", latencyMs: 12, version: "v1.30.1" }),
       sourcesReport: async () => ({
         chain: [{ path: "/Users/fixture/.kube/config", kind: "file", files: 1, contexts: 2, default: true }],
         configured: [],
@@ -382,6 +386,27 @@ test("context picker renders without overflow at both viewports", async ({ page 
   await page.setViewportSize({ width: 900, height: 640 });
   await expectNoOverflow(page, "context picker 900x640");
   await screenshot(page, "picker-900");
+  expect(failures).toEqual([]);
+});
+
+test("context picker shows cluster reachability status", async ({ page }) => {
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+
+  const ok = page.getByTestId("context-health-dev");
+  await expect(ok).toBeVisible();
+  await expect(ok).toHaveAttribute("data-state", "ok");
+  await expect(ok).toHaveAttribute("aria-label", "Reachable · v1.30.1 · 12 ms");
+
+  const down = page.getByTestId("context-health-prod");
+  await expect(down).toBeVisible();
+  await expect(down).toHaveAttribute("data-state", "error");
+  await expect(down).toHaveAttribute("aria-label", "Unreachable: dial tcp 10.0.0.2:443: i/o timeout");
+  // An unreachable cluster stays selectable: the status is advisory.
+  await expect(page.getByTestId("context-option-prod")).toBeEnabled();
+
+  await expectNoOverflow(page, "context picker health 1280x800");
   expect(failures).toEqual([]);
 });
 

--- a/core/internal/rpc/server.go
+++ b/core/internal/rpc/server.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,6 +18,7 @@ const maxRequestBody = 1 << 20
 
 type contextService interface {
 	Contexts() ([]session.ContextInfo, error)
+	Health(ctx context.Context, ids []string) []session.ContextHealth
 	SourceReports() session.SourcesReport
 	RenameEntry(path, kind, name, newName string) error
 }
@@ -37,6 +39,7 @@ func NewServer(token string, contexts contextService, resourceService *resources
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", server.health)
 	mux.HandleFunc("GET /v1/contexts", server.listContexts)
+	mux.HandleFunc("POST /v1/contexts/health", server.contextsHealth)
 	mux.HandleFunc("GET /v1/sources", server.listSources)
 	mux.HandleFunc("POST /v1/sources/rename", server.renameSource)
 	mux.HandleFunc("GET /v1/namespaces", server.listNamespaces)
@@ -95,6 +98,23 @@ func (s *Server) listContexts(writer http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) listSources(writer http.ResponseWriter, _ *http.Request) {
 	writeJSON(writer, http.StatusOK, s.contexts.SourceReports())
+}
+
+// contextHealthRequest asks the core to probe API server reachability for each
+// listed context (the picker's cluster status dots).
+type contextHealthRequest struct {
+	ContextIDs []string `json:"contextIds"`
+}
+
+func (s *Server) contextsHealth(writer http.ResponseWriter, request *http.Request) {
+	var value contextHealthRequest
+	if err := decodeJSON(writer, request, &value); err != nil {
+		return
+	}
+	if rejectInvalid(writer, validateContextHealthRequest(value)) {
+		return
+	}
+	writeJSON(writer, http.StatusOK, map[string]any{"health": s.contexts.Health(request.Context(), value.ContextIDs)})
 }
 
 // renameSourceRequest asks the core to resolve a kubeconfig name collision by

--- a/core/internal/rpc/server_test.go
+++ b/core/internal/rpc/server_test.go
@@ -30,6 +30,14 @@ func (f fakeContexts) Contexts() ([]session.ContextInfo, error) {
 	return f.values, nil
 }
 
+func (f fakeContexts) Health(_ context.Context, ids []string) []session.ContextHealth {
+	results := make([]session.ContextHealth, len(ids))
+	for index, id := range ids {
+		results[index] = session.ContextHealth{ID: id, Status: "ok", Version: "v1.30.0"}
+	}
+	return results
+}
+
 func (fakeContexts) SourceReports() session.SourcesReport {
 	return session.SourcesReport{}
 }
@@ -245,6 +253,41 @@ func TestServerValidatesHelmRequests(t *testing.T) {
 	server.Handler().ServeHTTP(response, missingChart)
 	if response.Code != http.StatusBadRequest || !contains(response.Body.String(), `"code":"invalid_request"`) {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestServerContextsHealth(t *testing.T) {
+	service := resources.NewService(rpcClientProvider{client: fake.NewSimpleDynamicClient(runtime.NewScheme())})
+	server, err := NewServer("token", fakeContexts{}, service, helm.NewService(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ok := httptest.NewRequest(http.MethodPost, "/v1/contexts/health", bytes.NewBufferString(`{"contextIds":["dev","prod"]}`))
+	ok.Header.Set("Authorization", "Bearer token")
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, ok)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	var body struct {
+		Health []session.ContextHealth `json:"health"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Health) != 2 || body.Health[0].ID != "dev" || body.Health[0].Status != "ok" || body.Health[1].ID != "prod" {
+		t.Fatalf("unexpected health payload: %+v", body.Health)
+	}
+
+	for _, payload := range []string{`{}`, `{"contextIds":[]}`, `{"contextIds":[""]}`} {
+		invalid := httptest.NewRequest(http.MethodPost, "/v1/contexts/health", bytes.NewBufferString(payload))
+		invalid.Header.Set("Authorization", "Bearer token")
+		response = httptest.NewRecorder()
+		server.Handler().ServeHTTP(response, invalid)
+		if response.Code != http.StatusBadRequest || !contains(response.Body.String(), `"code":"invalid_request"`) {
+			t.Fatalf("payload %s: status=%d body=%s", payload, response.Code, response.Body.String())
+		}
 	}
 }
 

--- a/core/internal/rpc/validate.go
+++ b/core/internal/rpc/validate.go
@@ -35,6 +35,7 @@ const (
 	maxSourcePath           = 4_096
 	maxRepoURL              = 2_048
 	maxChartVersion         = 128
+	maxHealthContexts       = 200
 )
 
 var mutationOperations = map[string]bool{
@@ -67,6 +68,21 @@ func validateContextID(value string) error {
 		return fmt.Errorf("contextId is required")
 	}
 	return checkLength("contextId", value, maxContextID)
+}
+
+func validateContextHealthRequest(value contextHealthRequest) error {
+	if len(value.ContextIDs) == 0 {
+		return fmt.Errorf("contextIds is required")
+	}
+	if len(value.ContextIDs) > maxHealthContexts {
+		return fmt.Errorf("contextIds must have at most %d entries", maxHealthContexts)
+	}
+	for _, id := range value.ContextIDs {
+		if err := validateContextID(id); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validateListRequest(value resources.ListRequest) error {

--- a/core/internal/session/health.go
+++ b/core/internal/session/health.go
@@ -1,0 +1,104 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// ContextHealth is the reachability probe result for one context. Status is
+// "ok" when the API server answered /version, "error" otherwise. Message is a
+// short, credential-free summary; it can name the server URL, which the
+// renderer already knows from ContextInfo.
+type ContextHealth struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	LatencyMs int64  `json:"latencyMs,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Message   string `json:"message,omitempty"`
+}
+
+const (
+	// healthTimeout bounds one probe. Four seconds keeps a dead cluster from
+	// stalling the picker while leaving room for VPN-warmed connections.
+	healthTimeout = 4 * time.Second
+	// healthConcurrency bounds the probe fan-out so a kubeconfig with
+	// hundreds of contexts does not open hundreds of sockets at once.
+	healthConcurrency = 8
+	// healthMessageMax caps the error text returned to the renderer.
+	healthMessageMax = 240
+)
+
+// serverVersion queries the cluster's /version endpoint. It is a field so
+// tests can probe fake clusters without a live API server.
+func defaultServerVersion(config *rest.Config) (string, error) {
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", err
+	}
+	info, err := client.Discovery().ServerVersion()
+	if err != nil {
+		return "", err
+	}
+	return info.GitVersion, nil
+}
+
+// Health probes each context's API server concurrently and reports per-context
+// reachability. It builds throwaway clients with a hard timeout: nothing is
+// cached and the manager's client maps are untouched, keeping probes outside
+// the lazy-client lifecycle. Results come back in request order.
+func (m *Manager) Health(ctx context.Context, ids []string) []ContextHealth {
+	results := make([]ContextHealth, len(ids))
+	semaphore := make(chan struct{}, healthConcurrency)
+	var wg sync.WaitGroup
+	for index, id := range ids {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case semaphore <- struct{}{}:
+				defer func() { <-semaphore }()
+			case <-ctx.Done():
+				results[index] = ContextHealth{ID: id, Status: "error", Message: "probe cancelled"}
+				return
+			}
+			results[index] = m.probe(id)
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+func (m *Manager) probe(id string) ContextHealth {
+	health := ContextHealth{ID: id, Status: "ok"}
+	config, err := m.loader.ClientConfig(id).ClientConfig()
+	if err != nil {
+		health.Status = "error"
+		health.Message = healthMessage(fmt.Errorf("load context %q: %w", id, err))
+		return health
+	}
+	config.Timeout = healthTimeout
+	config.UserAgent = "aster/0.1"
+	start := time.Now()
+	version, err := m.serverVersion(config)
+	if err != nil {
+		health.Status = "error"
+		health.Message = healthMessage(err)
+		return health
+	}
+	health.LatencyMs = time.Since(start).Milliseconds()
+	health.Version = version
+	return health
+}
+
+func healthMessage(err error) string {
+	message := err.Error()
+	if len(message) > healthMessageMax {
+		message = message[:healthMessageMax]
+	}
+	return message
+}

--- a/core/internal/session/health_test.go
+++ b/core/internal/session/health_test.go
@@ -1,0 +1,91 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestManagerHealthReportsPerContext(t *testing.T) {
+	directory := t.TempDir()
+	writeTestFile(t, filepath.Join(directory, "config"), `
+apiVersion: v1
+kind: Config
+clusters:
+- name: dev-cluster
+  cluster:
+    server: https://dev.example.test
+- name: prod-cluster
+  cluster:
+    server: https://prod.example.test
+contexts:
+- name: dev
+  context:
+    cluster: dev-cluster
+    user: dev-user
+- name: prod
+  context:
+    cluster: prod-cluster
+    user: prod-user
+users:
+- name: dev-user
+  user:
+    token: secret-dev-token
+- name: prod-user
+  user:
+    token: secret-prod-token
+`)
+	rules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath.Join(directory, "config")}
+	manager := newManager(NewLoaderWithRules(rules), nil)
+	manager.serverVersion = func(config *rest.Config) (string, error) {
+		if config.Host == "https://prod.example.test" {
+			return "", errors.New("dial tcp: i/o timeout")
+		}
+		// The probe must carry a hard timeout so a dead cluster cannot stall
+		// the picker.
+		if config.Timeout != healthTimeout {
+			t.Errorf("probe timeout = %v, want %v", config.Timeout, healthTimeout)
+		}
+		return "v1.30.1", nil
+	}
+
+	results := manager.Health(context.Background(), []string{"dev", "prod"})
+	if len(results) != 2 {
+		t.Fatalf("got %d results", len(results))
+	}
+	if results[0].ID != "dev" || results[0].Status != "ok" || results[0].Version != "v1.30.1" {
+		t.Errorf("dev result = %+v", results[0])
+	}
+	if results[1].ID != "prod" || results[1].Status != "error" || results[1].Message != "dial tcp: i/o timeout" {
+		t.Errorf("prod result = %+v", results[1])
+	}
+}
+
+func TestManagerHealthReportsUnresolvableContext(t *testing.T) {
+	directory := t.TempDir()
+	writeTestFile(t, filepath.Join(directory, "config"), `
+apiVersion: v1
+kind: Config
+clusters: []
+contexts: []
+users: []
+`)
+	rules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath.Join(directory, "config")}
+	manager := newManager(NewLoaderWithRules(rules), nil)
+
+	results := manager.Health(context.Background(), []string{"ghost"})
+	if len(results) != 1 || results[0].Status != "error" || results[0].Message == "" {
+		t.Fatalf("ghost result = %+v", results)
+	}
+}
+
+func TestHealthMessageTruncates(t *testing.T) {
+	long := healthMessage(errors.New(string(make([]byte, healthMessageMax+50))))
+	if len(long) != healthMessageMax {
+		t.Fatalf("message length = %d, want %d", len(long), healthMessageMax)
+	}
+}

--- a/core/internal/session/manager.go
+++ b/core/internal/session/manager.go
@@ -29,6 +29,9 @@ type Manager struct {
 	loader      *Loader
 	factory     dynamicFactory
 	coreFactory func(*rest.Config) (kubernetes.Interface, error)
+	// serverVersion performs the /version probe behind Health; replaceable in
+	// tests so probes never need a live API server.
+	serverVersion func(*rest.Config) (string, error)
 
 	mu               sync.Mutex
 	clients          map[string]dynamic.Interface
@@ -70,6 +73,7 @@ func newManager(loader *Loader, factory dynamicFactory) *Manager {
 		loader:           loader,
 		factory:          factory,
 		coreFactory:      func(config *rest.Config) (kubernetes.Interface, error) { return kubernetes.NewForConfig(config) },
+		serverVersion:    defaultServerVersion,
 		clients:          make(map[string]dynamic.Interface),
 		coreClients:      make(map[string]kubernetes.Interface),
 		discoveryClients: make(map[string]discovery.DiscoveryInterface),


### PR DESCRIPTION
## Summary

Closes #14. The context picker listed clusters with no reachability signal — the core only parsed kubeconfig statically, so there was no status data anywhere in the chain. This adds an advisory health probe end to end:

- **Core**: new `POST /v1/contexts/health` endpoint. For each context ID it dials the API server's `/version` with a 4s hard timeout and bounded fan-out (8 concurrent). Probes use throwaway clients: nothing is cached and the manager's lazy client maps/locks are untouched, preserving the no-startup-sync boundary. Validation caps the request at 200 IDs. Probe results carry only a status enum, latency, server version, and a truncated error message — no credentials or kubeconfig contents.
- **Shell**: `contexts_health` Tauri command proxies the probe to the core (token and loopback URL never cross into the renderer).
- **Renderer**: the list renders as fast as before (loading ends when the list arrives); each row's status dot then fills in — grey pulse while checking, green with version/latency tooltip when reachable, red with a short reason when not. Refresh re-probes; a stale probe round can't overwrite a newer one. Unreachable rows stay selectable since `/version` can be rejected while real requests succeed. Checking animation respects `prefers-reduced-motion`.

## Test plan

- [x] `pnpm typecheck` / `pnpm test` / `pnpm build`
- [x] `go -C core test -race ./...` / `go -C core vet ./...` (new probe + endpoint validation tests)
- [x] `cargo test` / `cargo clippy --all-targets`
- [x] `pnpm --dir apps/desktop smoke:visual` — 25 passed, incl. new "context picker shows cluster reachability status" (ok/error dots, aria labels, advisory-only behavior, no overflow)
- [x] Manual: `pnpm dev` against a real kubeconfig (required for shell changes)