### PR TITLE
feat(kubeconfig): import a cluster by pasting kubeconfig content

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -208,9 +208,25 @@ pub fn settings_set_kubeconfig_sources(state: State<'_, AppState>, sources: Vec<
 pub async fn settings_apply_kubeconfig_sources(state: State<'_, AppState>, sources: Vec<String>, include_standard_chain: bool) -> Result<(), String> {
     let settings = AsterSettings { kubeconfig_sources: normalize_sources(sources), include_standard_chain };
     state.settings.write(&settings);
+    // Managed paste-imports the new list no longer references are deleted so a
+    // removed source does not leave an orphaned credential file on disk.
+    crate::kubeconfig_import::prune_unreferenced(&crate::kubeconfig_import::managed_kubeconfig_dir(), &settings.kubeconfig_sources);
     // Restarting the core invalidates every live stream.
     state.streams.cancel_all();
     state.sidecar.restart().await
+}
+
+#[tauri::command]
+pub fn import_kubeconfig_content(name: Option<String>, content: String) -> Result<String, String> {
+    // One-way handoff: pasted text enters the shell here and is never returned
+    // to the renderer; only the written path crosses back. The sniff rejects
+    // obvious non-kubeconfigs up front; the Go core stays the authoritative
+    // validator once the path becomes a source.
+    let first_context = crate::kubeconfig_import::sniff_kubeconfig(&content)?;
+    let slug_source = name.as_deref().map(str::trim).filter(|value| !value.is_empty()).unwrap_or(&first_context);
+    let dir = crate::kubeconfig_import::managed_kubeconfig_dir();
+    let path = crate::kubeconfig_import::write_managed(&dir, &crate::kubeconfig_import::slugify(slug_source), &content)?;
+    Ok(path.to_string_lossy().into_owned())
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/kubeconfig_import.rs
+++ b/apps/desktop/src-tauri/src/kubeconfig_import.rs
@@ -1,0 +1,295 @@
+//! Paste-to-import for kubeconfigs. The renderer hands the pasted text to the
+//! shell (one-way; contents are never returned), which writes it into an
+//! app-managed directory next to `config.yaml` and returns the path so it can
+//! be added as a kubeconfig source like any picked file.
+//!
+//! This deliberately amends the "kubeconfig contents are never copied" stance
+//! noted in settings.rs: pasted configs exist only as text in the renderer, so
+//! importing means copying them into a managed file (mode 0600). Files under
+//! the managed directory are owned by the app — they are pruned when an apply
+//! leaves them unreferenced.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Kubeconfigs are small; the cap rejects accidents (whole directories of
+/// YAML, a binary paste) before they touch the disk.
+pub const MAX_CONTENT_BYTES: usize = 1 << 20;
+
+/// XDG-aware base for Aster's config files; shared with SettingsFile.
+pub fn config_base_dir() -> PathBuf {
+    std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".config"))
+        .join("aster")
+}
+
+pub fn managed_kubeconfig_dir() -> PathBuf {
+    config_base_dir().join("kubeconfigs")
+}
+
+/// Lightweight structural sniff. The Go core remains the authoritative
+/// validator (it re-parses every source on load and reports errors per
+/// source); this only keeps obvious non-kubeconfigs from ever hitting the
+/// disk, with errors specific enough to fix the paste. Returns the first
+/// context name found, used as the default file slug.
+pub fn sniff_kubeconfig(content: &str) -> Result<String, String> {
+    if content.len() > MAX_CONTENT_BYTES {
+        return Err(format!("content exceeds the {} KiB limit", MAX_CONTENT_BYTES / 1024));
+    }
+    if content.trim().is_empty() {
+        return Err("nothing pasted".to_string());
+    }
+    if content.contains('\t') {
+        // YAML forbids tabs for indentation; a tabbed paste is always a copy
+        // artifact, so name it instead of failing later in the core.
+        return Err("the pasted text contains tab characters, which YAML forbids".to_string());
+    }
+
+    let mut has_api_version = false;
+    let mut has_kind_config = false;
+    let mut in_contexts = false;
+    let mut first_context: Option<String> = None;
+    let mut contexts_seen = 0usize;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        // Block sequences may sit at column 0 under their key (that is how
+        // kubectl writes them), so a `- ` line never ends the contexts block.
+        let top_level = !line.starts_with(char::is_whitespace) && !trimmed.starts_with("- ");
+        if top_level {
+            in_contexts = false;
+            if trimmed.starts_with("apiVersion:") {
+                has_api_version = true;
+                continue;
+            }
+            if let Some(value) = trimmed.strip_prefix("kind:") {
+                if value.trim().trim_matches(|c| c == '"' || c == '\'') == "Config" {
+                    has_kind_config = true;
+                }
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix("contexts:") {
+                let rest = rest.trim();
+                if rest.is_empty() {
+                    in_contexts = true;
+                } else if rest != "[]" {
+                    // Inline list form (`contexts: [{...}]`) is valid YAML but
+                    // never emitted by tooling; accept it without parsing.
+                    contexts_seen += 1;
+                }
+                continue;
+            }
+            continue;
+        }
+        if in_contexts && trimmed.starts_with("- ") {
+            contexts_seen += 1;
+            if first_context.is_none() {
+                if let Some(value) = trimmed.strip_prefix("- name:") {
+                    let name = value.trim().trim_matches(|c| c == '"' || c == '\'');
+                    if !name.is_empty() {
+                        first_context = Some(name.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    if !has_api_version || !has_kind_config {
+        return Err("the pasted text does not look like a kubeconfig (missing apiVersion/kind: Config)".to_string());
+    }
+    if contexts_seen == 0 {
+        return Err("no contexts found in the pasted kubeconfig".to_string());
+    }
+    Ok(first_context.unwrap_or_default())
+}
+
+/// Filesystem-safe slug for the managed file name. Empty input falls back to
+/// a generic stem so an unnamed paste still lands somewhere readable.
+pub fn slugify(name: &str) -> String {
+    let mut slug = String::with_capacity(name.len());
+    let mut last_dash = false;
+    for ch in name.trim().chars().flat_map(char::to_lowercase) {
+        let keep = ch.is_ascii_alphanumeric() || ch == '_' || ch == '-';
+        if keep {
+            slug.push(ch);
+            last_dash = false;
+        } else if !last_dash && !slug.is_empty() {
+            slug.push('-');
+            last_dash = true;
+        }
+    }
+    let slug = slug.trim_end_matches('-');
+    let mut slug = if slug.is_empty() { "cluster".to_string() } else { slug.to_string() };
+    slug.truncate(64);
+    slug
+}
+
+/// First free path for `slug` inside `dir`: `<slug>.yaml`, then `-2`, `-3`…
+fn unique_path(dir: &Path, slug: &str) -> PathBuf {
+    for suffix in 1.. {
+        let stem = if suffix == 1 { slug.to_string() } else { format!("{slug}-{suffix}") };
+        let candidate = dir.join(format!("{stem}.yaml"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    unreachable!()
+}
+
+/// Writes `content` into `dir` with owner-only permissions, atomically
+/// (temp file + rename, same pattern as the settings file). Re-pasting the
+/// exact same content returns the existing file instead of accumulating
+/// duplicates. Returns the final path.
+pub fn write_managed(dir: &Path, slug: &str, content: &str) -> Result<PathBuf, String> {
+    fs::create_dir_all(dir).map_err(|error| format!("cannot create {}: {error}", dir.display()))?;
+
+    // Content dedupe: the managed dir holds only files we wrote, so scanning
+    // it is bounded by our own 1 MiB cap per file and 64-source settings cap.
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("yaml") {
+                continue;
+            }
+            if fs::read_to_string(&path).map(|existing| existing == content).unwrap_or(false) {
+                return Ok(path);
+            }
+        }
+    }
+
+    let target = unique_path(dir, slug);
+    let tmp = dir.join(format!(".{}.tmp", target.file_name().unwrap_or_default().to_string_lossy()));
+    write_owner_only(&tmp, content.as_bytes()).map_err(|error| format!("cannot write {}: {error}", target.display()))?;
+    fs::rename(&tmp, &target).map_err(|error| format!("cannot write {}: {error}", target.display()))?;
+    Ok(target)
+}
+
+#[cfg(unix)]
+fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut file = fs::OpenOptions::new().write(true).create_new(true).mode(0o600).open(path)?;
+    file.write_all(bytes)
+}
+
+#[cfg(not(unix))]
+fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    fs::write(path, bytes)
+}
+
+/// Deletes managed files that no longer appear in `sources`. Called on apply
+/// so a removed source does not leave an orphaned credential file behind.
+/// Only files inside `dir` are ever touched; best-effort per file.
+pub fn prune_unreferenced(dir: &Path, sources: &[String]) {
+    let Ok(entries) = fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("yaml") {
+            continue;
+        }
+        let referenced = sources.iter().any(|source| Path::new(source) == path);
+        if !referenced {
+            let _ = fs::remove_file(&path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "apiVersion: v1\nkind: Config\nclusters:\n- name: dev\n  cluster:\n    server: https://dev.example\ncontexts:\n- name: dev-admin\n  context:\n    cluster: dev\n    user: dev\ncurrent-context: dev-admin\nusers:\n- name: dev\n  user:\n    token: abc\n";
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("aster-import-test-{}-{}", std::process::id(), tag));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn sniff_accepts_a_typical_kubeconfig_and_extracts_first_context() {
+        assert_eq!(sniff_kubeconfig(SAMPLE).unwrap(), "dev-admin");
+        // Indented sequence entries work too.
+        let indented = SAMPLE.replace("\n- name:", "\n  - name:");
+        assert_eq!(sniff_kubeconfig(&indented).unwrap(), "dev-admin");
+    }
+
+    #[test]
+    fn sniff_rejects_empty_oversized_and_non_kubeconfig_text() {
+        assert!(sniff_kubeconfig("   \n").unwrap_err().contains("nothing pasted"));
+        assert!(sniff_kubeconfig(&"x".repeat(MAX_CONTENT_BYTES + 1)).unwrap_err().contains("limit"));
+        assert!(sniff_kubeconfig("foo: bar\n").unwrap_err().contains("does not look like a kubeconfig"));
+        assert!(sniff_kubeconfig("apiVersion: v1\nkind: Pod\nmetadata:\n  name: x\n").unwrap_err().contains("does not look like a kubeconfig"));
+    }
+
+    #[test]
+    fn sniff_requires_at_least_one_context() {
+        let doc = "apiVersion: v1\nkind: Config\nclusters:\n- name: dev\n  cluster:\n    server: https://dev.example\n";
+        assert_eq!(sniff_kubeconfig(doc).unwrap_err(), "no contexts found in the pasted kubeconfig");
+        let empty_inline = "apiVersion: v1\nkind: Config\ncontexts: []\n";
+        assert_eq!(sniff_kubeconfig(empty_inline).unwrap_err(), "no contexts found in the pasted kubeconfig");
+        let inline = "apiVersion: v1\nkind: Config\ncontexts: [{name: dev}]\n";
+        assert!(sniff_kubeconfig(inline).is_ok());
+    }
+
+    #[test]
+    fn sniff_rejects_tabs() {
+        let doc = "apiVersion: v1\nkind: Config\ncontexts:\n\t- name: dev\n";
+        assert!(sniff_kubeconfig(doc).unwrap_err().contains("tab"));
+    }
+
+    #[test]
+    fn slugify_normalizes_and_falls_back() {
+        assert_eq!(slugify("Prod Admin (EU)"), "prod-admin-eu");
+        assert_eq!(slugify("  ***  "), "cluster");
+        assert_eq!(slugify("already_fine-1"), "already_fine-1");
+        assert_eq!(slugify(&"a".repeat(100)).len(), 64);
+    }
+
+    #[test]
+    fn write_managed_creates_0600_file_and_suffixes_collisions() {
+        let dir = temp_dir("write");
+        let first = write_managed(&dir, "dev", SAMPLE).unwrap();
+        assert_eq!(first, dir.join("dev.yaml"));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(fs::metadata(&first).unwrap().permissions().mode() & 0o777, 0o600);
+        }
+        let second = write_managed(&dir, "dev", "apiVersion: v1\nkind: Config\ncontexts:\n- name: other\n").unwrap();
+        assert_eq!(second, dir.join("dev-2.yaml"));
+    }
+
+    #[test]
+    fn write_managed_dedupes_identical_content() {
+        let dir = temp_dir("dedupe");
+        let first = write_managed(&dir, "dev", SAMPLE).unwrap();
+        let again = write_managed(&dir, "dev", SAMPLE).unwrap();
+        assert_eq!(first, again);
+        assert_eq!(fs::read_dir(&dir).unwrap().filter(|e| e.as_ref().unwrap().path().extension().and_then(|x| x.to_str()) == Some("yaml")).count(), 1);
+    }
+
+    #[test]
+    fn prune_removes_only_unreferenced_managed_yaml() {
+        let dir = temp_dir("prune");
+        let keep = write_managed(&dir, "keep", SAMPLE).unwrap();
+        let drop = write_managed(&dir, "drop", "apiVersion: v1\nkind: Config\ncontexts:\n- name: x\n").unwrap();
+        let outside = temp_dir("prune-outside").join("outside.yaml");
+        fs::write(&outside, SAMPLE).unwrap();
+        fs::write(dir.join("notes.txt"), "not a kubeconfig").unwrap();
+
+        prune_unreferenced(&dir, &[keep.to_string_lossy().into_owned(), outside.to_string_lossy().into_owned()]);
+
+        assert!(keep.exists());
+        assert!(!drop.exists());
+        assert!(outside.exists(), "prune must never touch files outside the managed dir");
+        assert!(dir.join("notes.txt").exists());
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod core_client;
+mod kubeconfig_import;
 mod menu;
 mod settings;
 mod sidecar;
@@ -133,6 +134,7 @@ pub fn run() {
             commands::settings_apply_kubeconfig_sources,
             commands::settings_pick_kubeconfig_file,
             commands::settings_pick_kubeconfig_folder,
+            commands::import_kubeconfig_content,
             commands::save_text_file,
             commands::appearance_set_theme_source,
             commands::updater_state,

--- a/apps/desktop/src-tauri/src/settings.rs
+++ b/apps/desktop/src-tauri/src/settings.rs
@@ -7,7 +7,8 @@ use serde::Serialize;
 /// Application settings on disk (~/.config/aster/config.yaml, honoring
 /// XDG_CONFIG_HOME). Port of src/main/settings.ts: the schema is a strict
 /// whitelist and kubeconfig sources are path references — file contents
-/// never enter the renderer and are never copied.
+/// never enter the renderer. One exception: paste-imported kubeconfigs are
+/// copied into an app-managed directory by design (see kubeconfig_import.rs).
 const MAX_SOURCES: usize = 64;
 const MAX_PATH_LENGTH: usize = 2048;
 
@@ -38,12 +39,7 @@ impl SettingsFile {
     }
 
     pub fn default_path() -> Self {
-        let base = std::env::var("XDG_CONFIG_HOME")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .map(PathBuf::from)
-            .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".config"));
-        Self::new(base.join("aster").join("config.yaml"))
+        Self::new(crate::kubeconfig_import::config_base_dir().join("config.yaml"))
     }
 
     pub fn read(&self) -> AsterSettings {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -469,6 +469,7 @@ export default function App() {
         }}
         onPickFile={() => desktop.settings.pickKubeconfigFile()}
         onPickFolder={() => desktop.settings.pickKubeconfigFolder()}
+        onImportKubeconfig={(name, content) => desktop.settings.importKubeconfigContent(name, content)}
         onCheckUpdates={checkForUpdates}
         onOpenExternal={(url) => void desktop.app.openExternal(url)}
         onBack={() => {
@@ -503,6 +504,18 @@ export default function App() {
         onOpenSettings={() => {
           contexts.setSettingsFrom(contexts.view);
           contexts.setView("settings");
+        }}
+        onPasteKubeconfig={async (name, content) => {
+          // The picker empty state has no Apply step behind it: stage the
+          // imported path and apply immediately so the pasted clusters load.
+          const path = await desktop.settings.importKubeconfigContent(name, content);
+          const sources = settings.kubeconfigSources.includes(path)
+            ? settings.kubeconfigSources
+            : [...settings.kubeconfigSources, path];
+          await desktop.settings.applyKubeconfigSources(sources, settings.includeStandardChain);
+          setSettings({ kubeconfigSources: sources, includeStandardChain: settings.includeStandardChain });
+          await contexts.loadContexts();
+          return path;
         }}
         onRenameConflict={async (request) => {
           await desktop.contexts.renameConflict(request);

--- a/apps/desktop/src/renderer/lib/desktop-tauri.ts
+++ b/apps/desktop/src/renderer/lib/desktop-tauri.ts
@@ -124,6 +124,7 @@ export function createTauriDesktopApi(): DesktopApi {
         invoke<void>("settings_apply_kubeconfig_sources", { sources, includeStandardChain }),
       pickKubeconfigFile: () => invoke<string | null>("settings_pick_kubeconfig_file"),
       pickKubeconfigFolder: () => invoke<string | null>("settings_pick_kubeconfig_folder"),
+      importKubeconfigContent: (name, content) => invoke<string>("import_kubeconfig_content", { name: name || null, content }),
     },
     discovery: {
       list: async (contextId) => discoveredResourceList(await invoke("discovery_list", { contextId })),

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -4424,6 +4424,66 @@ button.overview-card:focus-visible {
   margin-top: 2px;
 }
 
+/* ---- Paste kubeconfig dialog ---- */
+
+.paste-kubeconfig-dialog {
+  width: min(640px, calc(100vw - 40px));
+  max-width: 640px;
+}
+
+.paste-kubeconfig-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.paste-kubeconfig-content {
+  min-height: 240px;
+  max-height: 45vh;
+}
+
+.paste-kubeconfig-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.paste-kubeconfig-name {
+  height: 28px;
+  min-width: 0;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  outline: none;
+  background: var(--surface-muted);
+  color: var(--text);
+  font-size: 12px;
+}
+
+.paste-kubeconfig-name:focus {
+  border-color: var(--focus);
+}
+
+.paste-kubeconfig-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--failed) 35%, transparent);
+  border-radius: 8px;
+  color: var(--failed);
+  font-size: 12px;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.paste-kubeconfig-error svg {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
 /* ---- Log viewer (xterm surface) ---- */
 
 .log-viewer {

--- a/apps/desktop/src/renderer/views/ContextPicker.tsx
+++ b/apps/desktop/src/renderer/views/ContextPicker.tsx
@@ -4,6 +4,7 @@ import {
   ArrowRight,
   Boxes,
   CheckCircle2,
+  ClipboardPaste,
   LayoutGrid,
   List as ListIcon,
   LoaderCircle,
@@ -38,6 +39,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { ContextLayout } from "../lib/context-picker";
+import { PasteKubeconfigDialog } from "./PasteKubeconfigDialog";
 
 interface ContextPickerProps {
   core: CoreStatus;
@@ -57,6 +59,11 @@ interface ContextPickerProps {
   onRefresh(): void;
   onConnect(contextId?: string): void;
   onOpenSettings(): void;
+  /**
+   * Imports pasted kubeconfig content and applies it immediately (the empty
+   * state has no settings page behind it), resolving to the stored path.
+   */
+  onPasteKubeconfig(name: string, content: string): Promise<string>;
   /** Renames a colliding entry inside its kubeconfig file, then reloads contexts. */
   onRenameConflict(request: RenameConflictRequest): Promise<void>;
 }
@@ -78,10 +85,12 @@ function ContextPicker({
   onRefresh,
   onConnect,
   onOpenSettings,
+  onPasteKubeconfig,
   onRenameConflict,
 }: ContextPickerProps) {
   const listRef = useRef<HTMLDivElement>(null);
   const [conflictDialog, setConflictDialog] = useState<ContextInfo | null>(null);
+  const [pasteOpen, setPasteOpen] = useState(false);
   // Key of the conflict row whose rename form is open: path|kind|name.
   const [renaming, setRenaming] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
@@ -513,19 +522,29 @@ function ContextPicker({
                 description={
                   totalContexts
                     ? "Try another name or cluster."
-                    : "Add a kubeconfig file in Settings, then refresh."
+                    : "Paste a kubeconfig to import its clusters, or add a file in Settings."
                 }
                 action={
                   totalContexts ? undefined : (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={onOpenSettings}
-                      data-testid="context-picker-empty-settings"
-                    >
-                      <Settings data-icon="inline-start" aria-hidden="true" />
-                      Open Settings
-                    </Button>
+                    <>
+                      <Button
+                        type="button"
+                        data-testid="context-picker-empty-paste"
+                        onClick={() => setPasteOpen(true)}
+                      >
+                        <ClipboardPaste data-icon="inline-start" aria-hidden="true" />
+                        Paste kubeconfig
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={onOpenSettings}
+                        data-testid="context-picker-empty-settings"
+                      >
+                        <Settings data-icon="inline-start" aria-hidden="true" />
+                        Open Settings
+                      </Button>
+                    </>
                   )
                 }
               />
@@ -556,6 +575,8 @@ function ContextPicker({
           </footer>
         </section>
       </main>
+
+      <PasteKubeconfigDialog open={pasteOpen} onOpenChange={setPasteOpen} onImport={onPasteKubeconfig} />
 
       <Dialog
         open={Boolean(conflictDialog)}

--- a/apps/desktop/src/renderer/views/PasteKubeconfigDialog.tsx
+++ b/apps/desktop/src/renderer/views/PasteKubeconfigDialog.tsx
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ClipboardPaste, LoaderCircle, TriangleAlert } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export interface PasteKubeconfigDialogProps {
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  /**
+   * Imports the pasted content through the shell and resolves to the stored
+   * path. The parent owns whatever happens next (staging the path as a
+   * source in Settings, or applying immediately from the picker empty
+   * state). Rejections are shown in place so the paste can be fixed.
+   */
+  onImport(name: string, content: string): Promise<string>;
+}
+
+/**
+ * Paste-to-import dialog for kubeconfigs. The pasted text goes renderer →
+ * shell only: the shell sniffs it, writes it into the app-managed kubeconfig
+ * directory with owner-only permissions, and returns just the path. The name
+ * field is optional and only names the stored file; cluster naming still
+ * comes from the contexts inside the file.
+ */
+export function PasteKubeconfigDialog({ open, onOpenChange, onImport }: PasteKubeconfigDialogProps) {
+  const [name, setName] = useState("");
+  const [content, setContent] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    setName("");
+    setContent("");
+    setBusy(false);
+    setError("");
+  }, [open]);
+
+  const submit = async () => {
+    setBusy(true);
+    setError("");
+    try {
+      await onImport(name.trim(), content);
+      onOpenChange(false);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!busy) onOpenChange(next); }}>
+      <DialogContent className="paste-kubeconfig-dialog" data-testid="paste-kubeconfig-dialog">
+        <DialogHeader>
+          <DialogTitle>Paste a kubeconfig</DialogTitle>
+          <DialogDescription>
+            The contents are stored in Aster's own config directory with owner-only permissions and
+            listed as a kubeconfig source. They are never sent anywhere else.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="paste-kubeconfig-fields">
+          <textarea
+            aria-label="Kubeconfig YAML"
+            autoFocus
+            className="resource-yaml-editor paste-kubeconfig-content"
+            data-testid="paste-kubeconfig-content"
+            onChange={(event) => setContent(event.target.value)}
+            placeholder={"apiVersion: v1\nkind: Config\nclusters:\n- …"}
+            readOnly={busy}
+            spellCheck={false}
+            value={content}
+          />
+          <label className="paste-kubeconfig-field">
+            <span>Name (optional — names the stored file; defaults to the first context)</span>
+            <input
+              className="paste-kubeconfig-name"
+              data-testid="paste-kubeconfig-name"
+              disabled={busy}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="prod-admin"
+              spellCheck={false}
+              value={name}
+            />
+          </label>
+        </div>
+
+        {error ? (
+          <div className="paste-kubeconfig-error" data-testid="paste-kubeconfig-error" role="alert">
+            <TriangleAlert aria-hidden="true" className="size-4" />
+            <span>{error}</span>
+          </div>
+        ) : null}
+
+        <DialogFooter>
+          <Button variant="outline" disabled={busy} onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            data-testid="paste-kubeconfig-submit"
+            disabled={busy || !content.trim()}
+            onClick={() => void submit()}
+          >
+            {busy ? (
+              <LoaderCircle aria-hidden="true" className="spin size-3.5" />
+            ) : (
+              <ClipboardPaste data-icon="inline-start" />
+            )}
+            {busy ? "Importing…" : "Import"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/renderer/views/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/views/SettingsPage.tsx
@@ -3,6 +3,7 @@ import {
   ArrowLeft,
   AtSign,
   Boxes,
+  ClipboardPaste,
   FilePlus2,
   FolderOpen,
   Info,
@@ -19,6 +20,7 @@ import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PasteKubeconfigDialog } from "./PasteKubeconfigDialog";
 import {
   BUILT_IN_THEMES,
   getThemeDefinition,
@@ -52,6 +54,12 @@ export interface SettingsPageProps {
   onApply(sources: string[], includeStandardChain: boolean): Promise<void>;
   onPickFile(): Promise<string | null>;
   onPickFolder(): Promise<string | null>;
+  /**
+   * Imports pasted kubeconfig content via the shell and resolves to the
+   * stored path; the path is staged as a source here and only takes effect
+   * on Apply, exactly like a picked file.
+   */
+  onImportKubeconfig(name: string, content: string): Promise<string>;
   onCheckUpdates(): Promise<UpdaterSnapshot>;
   /** Opens an external URL in the system browser via the shell. */
   onOpenExternal(url: string): void;
@@ -86,10 +94,12 @@ const THEME_OPTIONS: { value: AppearanceTheme; label: string }[] = [
  * readable fixed-width column. The kubeconfig section keeps its contract —
  * the standard chain (default ~/.kube/config plus $KUBECONFIG) is a default,
  * not a privilege: the user can turn it off, and with no sources at all the
- * app simply has no clusters. User sources are path references only, files
- * are never copied or modified. Applying restarts the core and refreshes the
- * per-source report in place; the page stays open so the new counts are
- * visible.
+ * app simply has no clusters. User sources are path references; picked files
+ * are never copied or modified. Paste-imported kubeconfigs are the one
+ * exception: they exist only as text, so the shell stores a copy in its own
+ * managed directory (and deletes it when the source is removed and applied).
+ * Applying restarts the core and refreshes the per-source report in place;
+ * the page stays open so the new counts are visible.
  */
 export function SettingsPage({
   settings,
@@ -105,6 +115,7 @@ export function SettingsPage({
   onApply,
   onPickFile,
   onPickFolder,
+  onImportKubeconfig,
   onCheckUpdates,
   onOpenExternal,
   onBack,
@@ -116,6 +127,7 @@ export function SettingsPage({
   const [applied, setApplied] = useState(false);
   const [reportLoading, setReportLoading] = useState(false);
   const [pathInput, setPathInput] = useState("");
+  const [pasteOpen, setPasteOpen] = useState(false);
   const [updateState, setUpdateState] = useState<{ phase: "idle" | "checking" | "done"; message?: string }>({
     phase: "idle",
   });
@@ -144,6 +156,12 @@ export function SettingsPage({
   async function add(pick: () => Promise<string | null>) {
     const picked = await pick();
     if (picked && !sourcePaths.includes(picked)) setSourcePaths((current) => [...current, picked]);
+  }
+
+  async function importPasted(name: string, content: string) {
+    const path = await onImportKubeconfig(name, content);
+    if (!sourcePaths.includes(path)) setSourcePaths((current) => [...current, path]);
+    return path;
   }
 
   function addPath() {
@@ -410,6 +428,10 @@ export function SettingsPage({
                       <FolderOpen data-icon="inline-start" />
                       Add folder…
                     </Button>
+                    <Button variant="outline" disabled={busy} data-testid="settings-paste-kubeconfig" onClick={() => setPasteOpen(true)}>
+                      <ClipboardPaste data-icon="inline-start" />
+                      Paste…
+                    </Button>
                     <form
                       className="settings-path-form"
                       onSubmit={(event) => {
@@ -494,6 +516,7 @@ export function SettingsPage({
           </main>
         </div>
       </Tabs>
+      <PasteKubeconfigDialog open={pasteOpen} onOpenChange={setPasteOpen} onImport={importPasted} />
     </div>
   );
 }

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -518,6 +518,15 @@ export interface DesktopApi {
     setKubeconfigSources(sources: string[], includeStandardChain: boolean): Promise<AsterSettings>;
     pickKubeconfigFile(): Promise<string | null>;
     pickKubeconfigFolder(): Promise<string | null>;
+    /**
+     * Imports a pasted kubeconfig: the shell sniffs the content, writes it
+     * into the app-managed kubeconfig directory (mode 0600) and resolves to
+     * the written path, ready to be added as a source. Contents travel
+     * renderer → shell only and are never returned. Rejects with a
+     * human-readable reason when the text does not look like a kubeconfig.
+     * An empty name derives the file slug from the first context.
+     */
+    importKubeconfigContent(name: string, content: string): Promise<string>;
     applyKubeconfigSources(sources: string[], includeStandardChain: boolean): Promise<void>;
   };
   discovery: {

--- a/apps/desktop/tests/live/shim.ts
+++ b/apps/desktop/tests/live/shim.ts
@@ -128,6 +128,8 @@ const api: DesktopApi = {
     setKubeconfigSources: (sources, includeStandardChain) => Promise.resolve({ kubeconfigSources: sources, includeStandardChain }),
     pickKubeconfigFile: () => Promise.resolve(null),
     pickKubeconfigFolder: () => Promise.resolve(null),
+    // Paste import writes through the shell filesystem; there is no shell here.
+    importKubeconfigContent: () => Promise.reject(new Error("paste import is only available in the desktop app")),
     applyKubeconfigSources: () => Promise.resolve(),
   },
   discovery: {

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -166,6 +166,13 @@ const MOCK_DESKTOP_API = `
       applyKubeconfigSources: async () => undefined,
       pickKubeconfigFile: async () => null,
       pickKubeconfigFolder: async () => null,
+      importKubeconfigContent: async (name, content) => {
+        window.__asterImportedKubeconfig = { name, content };
+        if (!content.includes("kind: Config")) {
+          throw new Error("the pasted text does not look like a kubeconfig (missing apiVersion/kind: Config)");
+        }
+        return "/managed/kubeconfigs/" + (name.trim() || "dev-admin") + ".yaml";
+      },
     },
     discovery: { list: async () => discovery },
     namespaces: {
@@ -1067,6 +1074,71 @@ test("settings opens as a page and returns to the picker", async ({ page }) => {
   await settings.getByTestId("settings-back").click();
   await expect(page.getByTestId("context-picker")).toBeVisible();
   await expect(page.getByTestId("context-option-prod")).toBeVisible();
+});
+
+test("paste import stages a kubeconfig source in settings", async ({ page }) => {
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await page.getByTestId("context-picker-settings").click();
+  const settings = page.getByTestId("settings-page");
+  await settings.getByTestId("settings-tab-kubeconfig").click();
+
+  await settings.getByTestId("settings-paste-kubeconfig").click();
+  const dialog = page.getByTestId("paste-kubeconfig-dialog");
+  await expect(dialog).toBeVisible();
+
+  // A paste that is not a kubeconfig is rejected in place; nothing is staged.
+  await dialog.getByTestId("paste-kubeconfig-content").fill("foo: bar");
+  await dialog.getByTestId("paste-kubeconfig-submit").click();
+  await expect(dialog.getByTestId("paste-kubeconfig-error")).toContainText("does not look like a kubeconfig");
+  await expect(dialog).toBeVisible();
+
+  // A valid paste with a name stages the stored path as a pending source.
+  await dialog.getByTestId("paste-kubeconfig-content").fill(
+    ["apiVersion: v1", "kind: Config", "contexts:", "- name: prod-eu", "  context:", "    cluster: prod", "    user: admin"].join("\n"),
+  );
+  await dialog.getByTestId("paste-kubeconfig-name").fill("prod-eu");
+  await dialog.getByTestId("paste-kubeconfig-submit").click();
+  await expect(dialog).not.toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as { __asterImportedKubeconfig?: { name: string } }).__asterImportedKubeconfig?.name))
+    .toBe("prod-eu");
+  await expect(settings.getByTestId("settings-source-list")).toContainText("/managed/kubeconfigs/prod-eu.yaml");
+  await expect(settings.getByTestId("settings-apply")).toBeEnabled();
+
+  await expectNoOverflow(page, "paste kubeconfig import");
+  await screenshot(page, "settings-paste-import");
+  expect(failures).toEqual([]);
+});
+
+test("paste import from the picker empty state", async ({ page }) => {
+  await page.addInitScript(() => {
+    const desktop = (window as unknown as { __ASTER_DESKTOP__?: { contexts: Record<string, unknown> } }).__ASTER_DESKTOP__;
+    if (desktop) {
+      desktop.contexts.list = async () => [];
+      desktop.contexts.sourcesReport = async () => ({ chain: [], configured: [] });
+    }
+  });
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+
+  // The empty state leads with paste import; applying restarts the (mocked)
+  // core, the dialog closes, and the picker stays honest about zero contexts.
+  await expect(page.getByTestId("context-picker-empty")).toContainText("No contexts found");
+  await page.getByTestId("context-picker-empty-paste").click();
+  const dialog = page.getByTestId("paste-kubeconfig-dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByTestId("paste-kubeconfig-content").fill(
+    ["apiVersion: v1", "kind: Config", "contexts:", "- name: dev", "  context:", "    cluster: dev", "    user: dev"].join("\n"),
+  );
+  await dialog.getByTestId("paste-kubeconfig-submit").click();
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByTestId("context-picker-empty")).toBeVisible();
+  await expectNoOverflow(page, "picker empty-state paste import");
+  await screenshot(page, "picker-empty-paste");
+  expect(failures).toEqual([]);
 });
 
 test("settings opens with no kubeconfig at all", async ({ page }) => {


### PR DESCRIPTION
Closes #21.

## What

Adds paste-based kubeconfig import with two entry points: a **Paste…** button in Settings → Kubeconfig, and a **Paste kubeconfig** button in the context picker's empty state.

## Design

- **One-way content flow**: pasted text goes renderer → shell only; contents are never returned to the renderer, keeping the existing credential boundary.
- **Lightweight sniff, no YAML parser**: the Rust shell rejects oversized (>1 MiB), tab-indented, or structurally implausible text (missing `apiVersion:`/`kind: Config`, zero contexts). kubectl's column-0 block sequences are handled. The Go core remains the authoritative validator via the existing per-source report.
- **Managed storage**: content is written atomically (tmp + rename) into `~/.config/aster/kubeconfigs/` with 0600 permissions, slug-de-duplicated (re-pasting identical content reuses the file). An optional display name drives the slug; empty falls back to the first context name.
- **Hygiene**: applying kubeconfig sources prunes managed files that are no longer referenced, so Remove + Apply deletes the stored copy.
- **Settings contract**: paste-import is the single deliberate exception to the "sources are path references only" invariant; both the Rust and renderer doc comments say so.

## Verification

- `cargo test` (24) + `cargo clippy` clean — 8 new unit tests for the sniff/slug/write/prune logic
- `pnpm typecheck`, `pnpm test` (86), `pnpm build`
- `smoke:visual`: 2 new Playwright tests (settings paste flow incl. rejection, picker empty-state paste)
- Manual `pnpm dev` run against a real kubeconfig: invalid paste rejected in place; valid paste stored 0600; Apply restarts the core and the new context appears in the picker; Remove + Apply prunes the file