### PR TITLE
fix(toolbar): keep IME composition text out of toolbar filtering

### DIFF
--- a/apps/desktop/src/renderer/shell/UnifiedToolbar.tsx
+++ b/apps/desktop/src/renderer/shell/UnifiedToolbar.tsx
@@ -110,6 +110,11 @@ export function UnifiedToolbar({
   ], [namespaces]);
   const selectedNamespace = namespaceItems.find((item) => item.value === (namespace || null)) ?? null;
   const [namespaceQuery, setNamespaceQuery] = useState("");
+  // IME composition text for the resource search. While it is non-null the
+  // input displays the in-progress composition (a controlled input would
+  // otherwise swallow it on the next render), but the query prop — and with it
+  // the resource filter — stays on the last committed text.
+  const [composingQuery, setComposingQuery] = useState<string | null>(null);
   // The popup is controlled so a direct-Enter commit (below) can close it even
   // when the typed value is not a list row Base UI would auto-select.
   const [namespaceOpen, setNamespaceOpen] = useState(false);
@@ -170,6 +175,10 @@ export function UnifiedToolbar({
           disabled={namespaceDisabled}
           items={namespaceItems}
           limit={NAMESPACE_MATCH_LIMIT}
+          // IME-safe: Base UI's input holds composition text back and only
+          // fires this for committed text (it calls setInputValue at
+          // compositionend). The direct-Enter keydown below needs its own
+          // isComposing guard because that handler is ours, not Base UI's.
           onInputValueChange={(inputValue) => setNamespaceQuery(inputValue)}
           onOpenChange={(open) => {
             setNamespaceOpen(open);
@@ -211,6 +220,10 @@ export function UnifiedToolbar({
                       // when there is nothing to select — the list is still
                       // loading or the filter matched nothing.
                       if (event.key !== "Enter" || namespaceSearch.shown.length > 0) return;
+                      // The Enter that commits an IME composition reports
+                      // key "Enter" with isComposing (keyCode 229); it belongs
+                      // to the input method, never to the direct-Enter commit.
+                      if (event.nativeEvent.isComposing) return;
                       event.preventDefault();
                       event.stopPropagation();
                       commitNamespaceInput();
@@ -257,11 +270,29 @@ export function UnifiedToolbar({
         <input
           aria-label="Filter current resources"
           data-testid="resource-search"
-          onChange={(event) => onQueryChange(event.target.value)}
+          onChange={(event) => {
+            // React fires onChange for every keystroke of an IME composition
+            // (e.g. pinyin "d'e's"); those intermediate strings must not drive
+            // the filter. The composition text is mirrored into local state so
+            // the controlled input still displays it.
+            if ((event.nativeEvent as InputEvent).isComposing) {
+              setComposingQuery(event.target.value);
+              return;
+            }
+            setComposingQuery(null);
+            onQueryChange(event.target.value);
+          }}
+          onCompositionEnd={(event) => {
+            // Commits once per composition; browsers that fire the final
+            // input event after compositionend commit again via onChange with
+            // the same text, which is idempotent.
+            setComposingQuery(null);
+            onQueryChange(event.currentTarget.value);
+          }}
           placeholder={searchPlaceholder}
           ref={queryInputRef}
           type="search"
-          value={query}
+          value={composingQuery ?? query}
         />
         <Badge aria-hidden="true" className="shortcut" variant="outline">
           <Command aria-hidden="true" className="size-2.5" />F

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -1568,6 +1568,102 @@ test("namespace picker Enter selects the highlighted row when matches exist", as
   expect(failures).toEqual([]);
 });
 
+test("toolbar inputs ignore IME composition until it commits", async ({ page }) => {
+  // CJK input methods fire real input events for every composition keystroke
+  // (e.g. pinyin "d'e"); the toolbar must keep filtering on the last
+  // committed text and only apply the composition once it ends. The
+  // composition text itself must stay visible in both inputs.
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await connectToDev(page);
+
+  const grid = page.getByRole("grid", { name: "Resources" });
+  // Anchor on the row's accessible name ("Select deployments-3 …"): raw
+  // textContent runs cells together, so neither substring nor \b can tell
+  // "deployments-3" apart from "deployments-31".
+  const row = (name: string) =>
+    grid.getByRole("row", { name: new RegExp(`^Select ${name} `) });
+
+  // Simulate an IME: compositionstart, then input events with isComposing,
+  // then a compositionend carrying the committed text. The value is set
+  // before compositionstart so controlled inputs observe it in the same
+  // order real keystrokes produce.
+  const startComposition = (testId: string, composition: string) =>
+    page.evaluate(([id, text]) => {
+      const input = document.querySelector<HTMLInputElement>(`[data-testid="${id}"]`)!;
+      input.value = text;
+      input.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true, data: "" }));
+      input.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: text,
+        inputType: "insertCompositionText",
+        isComposing: true,
+      }));
+    }, [testId, composition]);
+  const commitComposition = (testId: string, committed: string) =>
+    page.evaluate(([id, text]) => {
+      const input = document.querySelector<HTMLInputElement>(`[data-testid="${id}"]`)!;
+      input.value = text;
+      input.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true, data: text }));
+    }, [testId, committed]);
+
+  await expect(row("deployments-0")).toBeVisible({ timeout: 15_000 });
+
+  // Resource search: the in-progress pinyin is displayed but never filters.
+  await startComposition("resource-search", "d'e");
+  const search = page.getByTestId("resource-search");
+  await expect(search).toHaveValue("d'e");
+  await expect(row("deployments-0")).toBeVisible();
+
+  // The committed text filters exactly once, when the composition ends.
+  await commitComposition("resource-search", "deployments-3");
+  await expect(search).toHaveValue("deployments-3");
+  await expect(row("deployments-3")).toBeVisible();
+  await expect(row("deployments-0")).toHaveCount(0);
+
+  // Namespace picker: composition text must not enter the prefix search.
+  await page.getByTestId("namespace-select").click();
+  const filter = page.getByTestId("namespace-filter");
+  await expect(filter).toBeVisible();
+
+  // First commit a query that matches nothing, so the direct-Enter path is
+  // armed; then compose on top of it. The Enter that commits an IME
+  // composition (Chrome reports key "Enter", keyCode 229, isComposing) must
+  // not run that commit path or switch the namespace.
+  await commitComposition("namespace-filter", "zzz-no-match");
+  await expect(page.locator(".namespace-combobox-empty")).toContainText("No matching namespaces");
+  await startComposition("namespace-filter", "d'e");
+  await expect(filter).toHaveValue("d'e");
+  await page.evaluate(() => {
+    const input = document.querySelector<HTMLInputElement>('[data-testid="namespace-filter"]')!;
+    const enter = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      isComposing: true,
+      key: "Enter",
+    });
+    Object.defineProperty(enter, "keyCode", { get: () => 229 });
+    Object.defineProperty(enter, "which", { get: () => 229 });
+    input.dispatchEvent(enter);
+  });
+  // The composition is still in progress: the picker stays open and the
+  // namespace is untouched — the IME's Enter must never commit the raw
+  // pinyin or the armed "zzz-no-match" query as the namespace.
+  await expect(filter).toBeVisible();
+  await expect(page.getByTestId("namespace-select")).toContainText("default");
+
+  // Ending the composition applies the committed text to the prefix search.
+  await commitComposition("namespace-filter", "kube");
+  await expect(page.locator(".namespace-combobox-item", { hasText: "kube-system" })).toBeVisible();
+  await expect(page.locator(".namespace-combobox-empty")).not.toContainText("No matching namespaces");
+  await filter.focus();
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("namespace-select")).toContainText("kube-system");
+  await screenshot(page, "toolbar-ime-composition");
+  expect(failures).toEqual([]);
+});
+
 test("command palette shows a loading row while the namespace list loads", async ({ page }) => {
   // Issue #15 scopes the loading placeholder to the palette too: opening ⌘K
   // during the first fetch must say so instead of showing only


### PR DESCRIPTION
Fixes #13

## What changed

- **Resource search box** (`UnifiedToolbar.tsx`): React fires `onChange` on every keystroke of an IME composition, so intermediate pinyin (e.g. `d'e`) drove the resource filter. The input now mirrors composition text into local state (so the controlled input keeps displaying the in-progress pinyin instead of swallowing it on re-render) and only calls `onQueryChange` with committed text — via `onChange` with `isComposing` false, or `compositionend`. Browsers that fire the final input event after `compositionend` commit twice with the same text, which is idempotent.
- **Namespace picker direct-Enter**: the custom keydown handler committed the raw input value on the Enter that *commits an IME composition* (Chrome reports `key: "Enter"`, `isComposing: true`, keyCode 229) whenever the last committed query had no matches. The handler now returns early when `nativeEvent.isComposing`.
- **Prefix search itself needed no change**: Base UI 1.7.0's `Combobox.Input` already holds composition text back (`isComposingRef` — it skips `setInputValue` during composition and fires `onInputValueChange` once at `compositionend`). A comment in the component documents this dependency so an upgrade doesn't silently regress it.

## Verification

- New smoke test `toolbar inputs ignore IME composition until it commits` simulates `compositionstart` / `InputEvent(isComposing)` / `compositionend` on both inputs: composition text is displayed but does not filter, the IME-Enter does not commit a namespace, and the committed text filters exactly once when the composition ends.
- `pnpm typecheck` ✅ · `pnpm test` (98) ✅ · `pnpm build` ✅ · `pnpm --dir apps/desktop smoke:visual` (37, incl. screenshots + overflow checks) ✅

Out of scope per the issue: stripping RFC 1123-invalid characters from committed queries.