### PR TITLE
fix(detail): keep single-letter shortcuts inert behind the dry-run review modal

### DIFF
--- a/apps/desktop/src/renderer/detail/ResourceDetailView.tsx
+++ b/apps/desktop/src/renderer/detail/ResourceDetailView.tsx
@@ -124,7 +124,9 @@ export function ResourceDetailView({
     if (!row) return;
     const actions = new Set(resourceActionsFor(row.kind).map((action) => action.id));
     const onKey = (event: KeyboardEvent) => {
-      if (operationDialog || mutationBusy) return;
+      // pendingMutation: the dry-run review modal is up — re-firing a shortcut
+      // behind it would re-tab to YAML editing or overwrite the staged mutation.
+      if (operationDialog || mutationBusy || pendingMutation) return;
       const active = document.activeElement;
       if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) return;
       // ⌘⌫ for delete (standard macOS destructive gesture). Checked before the
@@ -152,7 +154,7 @@ export function ResourceDetailView({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [row, operationDialog, mutationBusy, onMutate]);
+  }, [row, operationDialog, mutationBusy, pendingMutation, onMutate]);
 
   // Workload facts parsed from the live YAML the core already shipped; powers
   // the conditions/strategy/selector rows, annotations, and the pods list.

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -865,6 +865,13 @@ test("object shortcuts drive the header actions", async ({ page }) => {
   await page.keyboard.press("Meta+Backspace");
   const review = page.getByTestId("mutation-review-dialog");
   await expect(review).toBeVisible({ timeout: 15_000 });
+
+  // Single-letter shortcuts must be inert while the dry-run review modal is
+  // open: pressing "e" behind it must not re-tab to YAML editing.
+  await page.keyboard.press("e");
+  await expect(detail.getByTestId("resource-yaml-editor")).toHaveCount(0);
+  await expect(review).toBeVisible();
+
   await review.getByRole("button", { name: "Cancel" }).click();
   await expect(review).not.toBeVisible();
   expect(failures).toEqual([]);


### PR DESCRIPTION
## What

While the dry-run review modal is open, object-scoped single-letter shortcuts stayed live behind it: `e` re-tabbed to YAML editing and `r` re-mutated, overwriting the staged mutation under review. The keyboard handler guarded `operationDialog` and `mutationBusy` but not `pendingMutation`.

## Fix

Freeze the shortcut handler on the staged-mutation state too (`pendingMutation` added to the early return and the effect deps).

## Test

- Extended `object shortcuts drive the header actions`: with the delete review modal open, pressing `e` must not open the YAML editor and the modal must stay up.
- `pnpm --dir apps/desktop typecheck`, vitest (98 passed), full Playwright smoke suite (36 passed).

Fixes #24