### PR TITLE
fix(picker): only offer the All-namespaces row on an empty filter

### DIFF
--- a/apps/desktop/src/renderer/shell/UnifiedToolbar.tsx
+++ b/apps/desktop/src/renderer/shell/UnifiedToolbar.tsx
@@ -104,17 +104,21 @@ export function UnifiedToolbar({
   const ThemeIcon = theme === "dark" ? Moon : theme === "light" ? Sun : SunMoon;
   // A null-valued first item is the "All namespaces" choice; the label map
   // keeps the raw value out of the trigger (Base UI renders values by default).
-  const namespaceItems = useMemo<NamespaceItem[]>(() => [
-    { value: null, label: "All namespaces" },
-    ...namespaces.map((item) => ({ value: item.name as string | null, label: item.name })),
-  ], [namespaces]);
-  const selectedNamespace = namespaceItems.find((item) => item.value === (namespace || null)) ?? null;
   const [namespaceQuery, setNamespaceQuery] = useState("");
   // IME composition text for the resource search. While it is non-null the
   // input displays the in-progress composition (a controlled input would
   // otherwise swallow it on the next render), but the query prop — and with it
   // the resource filter — stays on the last committed text.
   const [composingQuery, setComposingQuery] = useState<string | null>(null);
+  // The null row is offered only while the filter is empty: with a query, its
+  // "All namespaces" label would collide with a real namespace (e.g. "all") in
+  // Base UI's autoHighlight and let Enter pick cluster scope by mistake, and
+  // during loading it would sit highlighted above the direct-Enter commit.
+  const namespaceItems = useMemo<NamespaceItem[]>(() => [
+    ...(!namespaceQuery.trim() ? [{ value: null, label: "All namespaces" }] : []),
+    ...namespaces.map((item) => ({ value: item.name as string | null, label: item.name })),
+  ], [namespaces, namespaceQuery]);
+  const selectedNamespace = namespaceItems.find((item) => item.value === (namespace || null)) ?? null;
   // The popup is controlled so a direct-Enter commit (below) can close it even
   // when the typed value is not a list row Base UI would auto-select.
   const [namespaceOpen, setNamespaceOpen] = useState(false);
@@ -213,19 +217,29 @@ export function UnifiedToolbar({
                     placeholder="Filter namespaces"
                     data-testid="namespace-filter"
                     onKeyDown={(event) => {
+                      if (event.key !== "Enter") return;
                       // Yield to Base UI whenever a concrete row is selectable:
                       // with autoHighlight, Enter must select the highlighted
                       // row (e.g. "kube-system" for the prefix "kube-s"), not
-                      // commit the raw prefix. Direct-Enter only takes over
-                      // when there is nothing to select — the list is still
-                      // loading or the filter matched nothing.
-                      if (event.key !== "Enter" || namespaceSearch.shown.length > 0) return;
+                      // commit the raw prefix.
+                      if (namespaceSearch.shown.length > 0) return;
                       // The Enter that commits an IME composition reports
                       // key "Enter" with isComposing (keyCode 229); it belongs
                       // to the input method, never to the direct-Enter commit.
                       if (event.nativeEvent.isComposing) return;
                       event.preventDefault();
                       event.stopPropagation();
+                      // Empty filter with no rows: the list is still loading
+                      // (or the cluster has no namespaces) and the rendered
+                      // "All namespaces" row is the only selectable scope, so
+                      // commit the null scope directly instead of leaning on
+                      // Base UI's autoHighlight, which is unreliable while the
+                      // selection is not in the still-loading items.
+                      if (!namespaceQuery.trim()) {
+                        onNamespaceChange("");
+                        setNamespaceOpen(false);
+                        return;
+                      }
                       commitNamespaceInput();
                     }}
                   />

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -1664,6 +1664,93 @@ test("toolbar inputs ignore IME composition until it commits", async ({ page }) 
   expect(failures).toEqual([]);
 });
 
+test("namespace picker Enter respects the All-namespaces row while loading", async ({ page }) => {
+  // The "All namespaces" row renders and auto-highlights with an empty filter
+  // even before the list loads. Enter must select that highlighted row (issue
+  // #23), not fall through to the dead direct-Enter commit — and a query that
+  // collides with the label ("all") must still commit raw while nothing is
+  // highlighted, because the null row is only offered with an empty filter.
+  await page.addInitScript(() => {
+    const desktop = (window as unknown as {
+      __ASTER_DESKTOP__?: { namespaces: { list(contextId: string): Promise<unknown> } };
+    }).__ASTER_DESKTOP__;
+    if (desktop) {
+      const list = desktop.namespaces.list.bind(desktop.namespaces);
+      desktop.namespaces.list = async (contextId: string) => {
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        return list(contextId);
+      };
+    }
+  });
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await connectToDev(page);
+
+  const filter = page.getByTestId("namespace-filter");
+  await page.getByTestId("namespace-select").click();
+  await expect(filter).toBeVisible();
+  await expect(page.getByTestId("namespace-loading")).toBeVisible();
+
+  // Non-empty filter while loading: the null row is gone, nothing is
+  // highlighted, so direct-Enter commits the raw input.
+  await filter.fill("all");
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("namespace-select")).toHaveText("all");
+  await expect(filter).toBeHidden();
+
+  // Reopen with an empty filter while the fetch is still in flight: the
+  // "All namespaces" row sits highlighted, so Enter selects it instead of
+  // being swallowed.
+  await page.getByTestId("namespace-select").click();
+  await expect(filter).toBeVisible();
+  await expect(page.getByTestId("namespace-loading")).toBeVisible();
+  await filter.click();
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("namespace-select")).toHaveText("All namespaces");
+  await expect(filter).toBeHidden();
+  await screenshot(page, "namespace-enter-all-namespaces-row");
+  expect(failures).toEqual([]);
+});
+
+test("namespace picker Enter prefers a real namespace named all over cluster scope", async ({ page }) => {
+  // A cluster can have a namespace literally named "all". With a query typed,
+  // the null-valued "All namespaces" row must not shadow it in the list or
+  // autoHighlight (issue #23): Enter selects the namespace, not cluster scope.
+  await page.addInitScript(() => {
+    const desktop = (window as unknown as {
+      __ASTER_DESKTOP__?: { namespaces: { list(contextId: string): Promise<unknown> } };
+    }).__ASTER_DESKTOP__;
+    if (desktop) {
+      desktop.namespaces.list = async () => ({
+        namespaces: [
+          { name: "all", status: "Active" },
+          { name: "default", status: "Active" },
+          { name: "kube-system", status: "Active" },
+        ],
+        truncated: false,
+      });
+    }
+  });
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await connectToDev(page);
+
+  await page.getByTestId("namespace-select").click();
+  const filter = page.getByTestId("namespace-filter");
+  await filter.fill("all");
+  // The null row is filtered out with a query, so only the real namespace
+  // named "all" survives (hasText is case-insensitive, hence the anchor).
+  const rows = page.locator(".namespace-combobox-item");
+  await expect(rows.filter({ hasText: /^all$/ })).toBeVisible();
+  await expect(rows.filter({ hasText: "All namespaces" })).toHaveCount(0);
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("namespace-select")).toHaveText("all");
+  await screenshot(page, "namespace-enter-named-all");
+  expect(failures).toEqual([]);
+});
+
 test("command palette shows a loading row while the namespace list loads", async ({ page }) => {
   // Issue #15 scopes the loading placeholder to the palette too: opening ⌘K
   // during the first fetch must say so instead of showing only


### PR DESCRIPTION
## What

The null-valued "All namespaces" row is always the first Combobox item, so Base UI's autoHighlight and internal filter made it interfere with the direct-Enter guard in three reachable ways (issue #23):

1. Loading + empty filter: the row sat highlighted but `shown.length === 0`, so Enter was intercepted and then dead.
2. A namespace literally named `all`: query "all" matched both rows and autoHighlight picked the null row, so Enter selected cluster scope instead of the namespace.
3. Loading + query "all": Enter committed "all" while the highlighted "All namespaces" row was on screen.

## Fix

- Offer the null row only while the filter is empty. With a query, it cannot collide with a real namespace or shadow the direct-Enter commit (cases 2 and 3).
- When an empty filter has no concrete rows (list still loading, or an empty cluster), commit the null scope directly instead of leaning on autoHighlight, which is unreliable while the selection is not in the still-loading items (case 1).

## Test

- New smoke test: `namespace picker Enter respects the All-namespaces row while loading` (direct-Enter of "all" while loading + Enter selecting All namespaces on an empty filter).
- New smoke test: `namespace picker Enter prefers a real namespace named all over cluster scope`.
- `pnpm --dir apps/desktop typecheck`, vitest (98 passed), full Playwright smoke suite (38 passed).

Fixes #23