### PR TITLE
feat(onboarding): first-run welcome card, cluster-less empty state, and help entry points

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -73,6 +73,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-updater",
+ "time",
  "tokio",
  "tokio-util",
 ]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ rand = "0.8"
 futures-util = "0.3"
 bytes = "1"
 dirs = "6"
+time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -199,14 +199,39 @@ pub fn settings_get(state: State<'_, AppState>) -> AsterSettings {
 
 #[tauri::command]
 pub fn settings_set_kubeconfig_sources(state: State<'_, AppState>, sources: Vec<String>, include_standard_chain: bool) -> AsterSettings {
-    let settings = AsterSettings { kubeconfig_sources: normalize_sources(sources), include_standard_chain };
+    // The struct-update base carries every unrelated field (the welcome
+    // stamp) forward: rewriting the sources must not resurrect the card.
+    let settings = AsterSettings {
+        kubeconfig_sources: normalize_sources(sources),
+        include_standard_chain,
+        ..state.settings.read()
+    };
     state.settings.write(&settings);
     settings
 }
 
+/// Records that the first-run welcome card has been dismissed. The shell
+/// stamps the time and stores it; deciding when to show the card is the
+/// renderer's. Idempotent: an existing stamp is kept.
+#[tauri::command]
+pub fn settings_mark_welcomed(state: State<'_, AppState>) -> AsterSettings {
+    state.settings.mark_welcomed_with(&now_rfc3339_utc())
+}
+
+fn now_rfc3339_utc() -> String {
+    use time::format_description::well_known::Rfc3339;
+    time::OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
 #[tauri::command]
 pub async fn settings_apply_kubeconfig_sources(state: State<'_, AppState>, sources: Vec<String>, include_standard_chain: bool) -> Result<(), String> {
-    let settings = AsterSettings { kubeconfig_sources: normalize_sources(sources), include_standard_chain };
+    let settings = AsterSettings {
+        kubeconfig_sources: normalize_sources(sources),
+        include_standard_chain,
+        ..state.settings.read()
+    };
     state.settings.write(&settings);
     // Managed paste-imports the new list no longer references are deleted so a
     // removed source does not leave an orphaned credential file on disk.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -44,6 +44,13 @@ pub fn run() {
         .on_menu_event(|app, event| {
             if let Some(command) = event.id().0.strip_prefix("cmd:") {
                 let _ = app.emit("app:command", command);
+                return;
+            }
+            // Help-menu links carry their URL as the id; open them through the
+            // same opener channel the renderer uses so the https-only rule
+            // stays in one place.
+            if let Some(url) = event.id().0.strip_prefix("link:") {
+                let _ = commands::app_open_external(app.clone(), url.to_string());
             }
         })
         .setup(|app| {
@@ -131,6 +138,7 @@ pub fn run() {
             commands::workloads_logs_follow_stop,
             commands::settings_get,
             commands::settings_set_kubeconfig_sources,
+            commands::settings_mark_welcomed,
             commands::settings_apply_kubeconfig_sources,
             commands::settings_pick_kubeconfig_file,
             commands::settings_pick_kubeconfig_folder,

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -1,6 +1,14 @@
 use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 use tauri::{AppHandle, Runtime};
 
+/// Canonical external destinations for the Help menu. The menu items carry
+/// these as their command ids (link: prefix); lib.rs opens them through the
+/// same opener channel the renderer uses, so https-only validation stays in
+/// one place.
+pub const DOCS_URL: &str = "https://github.com/zjy365/aster/blob/main/docs/quickstart.md";
+pub const REPORT_URL: &str = "https://github.com/zjy365/aster/issues";
+pub const REPO_URL: &str = "https://github.com/zjy365/aster";
+
 /// Port of installApplicationMenu from src/main/window.ts. Command items use
 /// the "cmd:" id prefix; lib.rs turns those into "app:command" events.
 pub fn install<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
@@ -46,6 +54,11 @@ pub fn install<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         .item(&PredefinedMenuItem::minimize(app, None)?)
         .item(&PredefinedMenuItem::close_window(app, None)?)
         .build()?;
+    let help = SubmenuBuilder::new(app, "Help")
+        .item(&MenuItemBuilder::with_id(format!("link:{DOCS_URL}"), "Quickstart Docs").build(app)?)
+        .item(&MenuItemBuilder::with_id(format!("link:{REPORT_URL}"), "Report Issue").build(app)?)
+        .item(&MenuItemBuilder::with_id(format!("link:{REPO_URL}"), "GitHub Repository").build(app)?)
+        .build()?;
 
     let mut menu = MenuBuilder::new(app);
     if cfg!(target_os = "macos") {
@@ -62,7 +75,7 @@ pub fn install<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
             .build()?;
         menu = menu.item(&app_menu);
     }
-    let menu = menu.items(&[&file, &edit, &navigate, &view, &window]).build()?;
+    let menu = menu.items(&[&file, &edit, &navigate, &view, &window, &help]).build()?;
     app.set_menu(menu)?;
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/settings.rs
+++ b/apps/desktop/src-tauri/src/settings.rs
@@ -20,11 +20,15 @@ pub struct AsterSettings {
     /// the user turns it off. It is a default, not a privilege: with it off
     /// and no configured sources the app simply has no clusters.
     pub include_standard_chain: bool,
+    /// RFC 3339 timestamp written when the first-run welcome card is dismissed.
+    /// Absent means never welcomed. The shell only stores it — deciding when
+    /// the card shows is the renderer's.
+    pub welcomed_at: Option<String>,
 }
 
 impl Default for AsterSettings {
     fn default() -> Self {
-        Self { kubeconfig_sources: Vec::new(), include_standard_chain: true }
+        Self { kubeconfig_sources: Vec::new(), include_standard_chain: true, welcomed_at: None }
     }
 }
 
@@ -60,6 +64,17 @@ impl SettingsFile {
             let _ = fs::rename(&target, &self.path);
         }
     }
+
+    /// Stamps the welcome time if absent and persists it. Idempotent: an
+    /// existing stamp is kept, so repeated dismisses never move it.
+    pub fn mark_welcomed_with(&self, stamp: &str) -> AsterSettings {
+        let mut settings = self.read();
+        if settings.welcomed_at.is_none() {
+            settings.welcomed_at = Some(stamp.to_string());
+            self.write(&settings);
+        }
+        settings
+    }
 }
 
 /// Parses the settings document; unknown keys are dropped, not merged.
@@ -68,6 +83,7 @@ pub fn parse_settings(document: &str) -> AsterSettings {
     // Absent means true, so settings files written by older versions keep
     // the chain.
     let mut include_standard_chain = true;
+    let mut welcomed_at: Option<String> = None;
     let mut in_list = false;
     for line in document.split('\n') {
         let trimmed = line.trim();
@@ -76,6 +92,12 @@ pub fn parse_settings(document: &str) -> AsterSettings {
         }
         if let Some(rest) = trimmed.strip_prefix("includeStandardChain:") {
             include_standard_chain = rest.trim() != "false";
+            in_list = false;
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("welcomedAt:") {
+            let value = unquote_yaml_string(rest.trim());
+            welcomed_at = (!value.is_empty()).then_some(value);
             in_list = false;
             continue;
         }
@@ -106,14 +128,20 @@ pub fn parse_settings(document: &str) -> AsterSettings {
         in_list = false;
     }
     sources.truncate(MAX_SOURCES);
-    AsterSettings { kubeconfig_sources: sources, include_standard_chain }
+    AsterSettings { kubeconfig_sources: sources, include_standard_chain, welcomed_at }
 }
 
 pub fn serialize_settings(settings: &AsterSettings) -> String {
-    // The chain flag is only written when off; its absence parses as on.
+    // The chain flag is only written when off; its absence parses as on. The
+    // welcomed stamp is only written when present; its absence parses as
+    // never welcomed.
     let mut output = String::new();
     if !settings.include_standard_chain {
         output.push_str("includeStandardChain: false\n");
+    }
+    if let Some(stamp) = &settings.welcomed_at {
+        let quoted = serde_json::to_string(stamp).unwrap_or_else(|_| format!("\"{stamp}\""));
+        output.push_str(&format!("welcomedAt: {quoted}\n"));
     }
     if settings.kubeconfig_sources.is_empty() {
         output.push_str("kubeconfigSources: []\n");
@@ -180,7 +208,11 @@ mod tests {
 
     #[test]
     fn serialize_round_trips_through_parse() {
-        let settings = AsterSettings { kubeconfig_sources: vec!["/a".into(), "/b c".into()], include_standard_chain: true };
+        let settings = AsterSettings {
+            kubeconfig_sources: vec!["/a".into(), "/b c".into()],
+            include_standard_chain: true,
+            welcomed_at: None,
+        };
         assert_eq!(parse_settings(&serialize_settings(&settings)).kubeconfig_sources, settings.kubeconfig_sources);
         assert_eq!(serialize_settings(&AsterSettings::default()), "kubeconfigSources: []\n");
     }
@@ -199,9 +231,56 @@ mod tests {
         assert!(!parse_settings("includeStandardChain: false\nkubeconfigSources: []").include_standard_chain);
         assert!(parse_settings("includeStandardChain: true\n").include_standard_chain);
 
-        let off = AsterSettings { kubeconfig_sources: vec![], include_standard_chain: false };
+        let off = AsterSettings { kubeconfig_sources: vec![], include_standard_chain: false, welcomed_at: None };
         let parsed = parse_settings(&serialize_settings(&off));
         assert!(!parsed.include_standard_chain);
         assert_eq!(serialize_settings(&AsterSettings::default()), "kubeconfigSources: []\n");
+    }
+
+    #[test]
+    fn welcomed_stamp_defaults_absent_and_round_trips() {
+        // Files written before the welcome card must parse as never welcomed.
+        assert_eq!(parse_settings("kubeconfigSources: []").welcomed_at, None);
+        assert_eq!(parse_settings("welcomedAt:\n").welcomed_at, None);
+
+        let document = "welcomedAt: \"2026-09-02T04:00:00Z\"\nkubeconfigSources: []\n";
+        assert_eq!(
+            parse_settings(document).welcomed_at.as_deref(),
+            Some("2026-09-02T04:00:00Z")
+        );
+
+        let welcomed = AsterSettings {
+            kubeconfig_sources: vec![],
+            include_standard_chain: true,
+            welcomed_at: Some("2026-09-02T04:00:00Z".into()),
+        };
+        let serialized = serialize_settings(&welcomed);
+        assert_eq!(parse_settings(&serialized).welcomed_at, welcomed.welcomed_at);
+        // The stamp never lands in a default (never-welcomed) document.
+        assert!(!serialize_settings(&AsterSettings::default()).contains("welcomedAt"));
+    }
+
+    #[test]
+    fn mark_welcomed_stamps_once_and_survives_source_rewrites() {
+        let directory = std::env::temp_dir().join(format!("aster-settings-test-{}", std::process::id()));
+        let file = SettingsFile::new(directory.join("config.yaml"));
+        // A pre-existing file from an older version: no stamp, chain on.
+        file.write(&AsterSettings { kubeconfig_sources: vec!["/a".into()], include_standard_chain: true, welcomed_at: None });
+
+        let stamped = file.mark_welcomed_with("2026-09-02T04:00:00Z");
+        assert_eq!(stamped.welcomed_at.as_deref(), Some("2026-09-02T04:00:00Z"));
+        // Idempotent: a second dismiss keeps the original stamp.
+        assert_eq!(
+            file.mark_welcomed_with("2027-01-01T00:00:00Z").welcomed_at.as_deref(),
+            Some("2026-09-02T04:00:00Z")
+        );
+        // Rewriting kubeconfig sources (the command's own shape) preserves it.
+        file.write(&AsterSettings {
+            kubeconfig_sources: vec!["/b".into()],
+            include_standard_chain: false,
+            welcomed_at: file.read().welcomed_at,
+        });
+        assert_eq!(file.read().welcomed_at.as_deref(), Some("2026-09-02T04:00:00Z"));
+        let _ = fs::remove_dir_all(&directory);
     }
 }

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -3,6 +3,7 @@ import { LoaderCircle, Ship } from "lucide-react";
 import type { AsterSettings, RelatedResource, ResourceKind, ResourceRow, SourcesReport } from "../shared/types";
 import { CommandPalette } from "./components/CommandPalette";
 import { UpdateNotice } from "./components/UpdateNotice";
+import { WelcomeCard } from "./components/WelcomeCard";
 import { ResourceTable, rowKey, TableState } from "./components/ResourceTable";
 import { Button } from "@/components/ui/button";
 import {
@@ -45,6 +46,9 @@ const ResourceDetailView = lazy(() => import("./detail/ResourceDetailView").then
 const CreateResourceDialog = lazy(() => import("./detail/CreateResourceDialog").then((module) => ({
   default: module.CreateResourceDialog,
 })));
+
+/** The settings shape used before the shell answers, and as its fallback. */
+const emptySettings: AsterSettings = { kubeconfigSources: [], includeStandardChain: true, welcomedAt: null };
 
 /**
  * Composition root: every domain owns its state in a hook above; this
@@ -139,7 +143,19 @@ export default function App() {
   const searchRef = useRef<HTMLInputElement>(null);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
-  const [settings, setSettings] = useState<AsterSettings>({ kubeconfigSources: [], includeStandardChain: true });
+  const [settings, setSettings] = useState<AsterSettings>(emptySettings);
+  // The welcome decision reads the *persisted* stamp, so it is inert until
+  // the shell has answered settings.get(): showing the card off the
+  // emptySettings fallback could flash it at returning users.
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
+  // First-run welcome: shown the first time a context apply lands on the
+  // workbench, gone forever once dismissed (the stamp lives in shell-owned
+  // settings; this is the only place that decides when it appears).
+  const [welcomeVisible, setWelcomeVisible] = useState(false);
+  const dismissWelcome = useCallback(() => {
+    setWelcomeVisible(false);
+    void desktop.settings.markWelcomed().then(setSettings).catch(() => undefined);
+  }, []);
   const [sourcesReport, setSourcesReport] = useState<SourcesReport>({ chain: [], configured: [] });
   const [appVersion, setAppVersion] = useState("");
   const reloadSources = useCallback(async () => {
@@ -307,7 +323,10 @@ export default function App() {
     contexts.setContextId(target.id);
     contexts.setView("workbench");
     localStorage.setItem("aster.lastContext", target.id);
-  }, [contexts, core.state, namespaces]);
+    // A successful entry into a cluster is the moment the welcome card is
+    // worth showing: the palette and list keys it teaches only exist here.
+    if (settingsLoaded && !settings.welcomedAt) setWelcomeVisible(true);
+  }, [contexts, core.state, namespaces, settingsLoaded, settings.welcomedAt]);
 
   const showContextPicker = useCallback(() => {
     contexts.setContextChoice(contextId);
@@ -445,7 +464,12 @@ export default function App() {
   const searchItems = useMemo(() => searchResultItems(searchResults, paletteQuery), [searchResults, paletteQuery]);
 
   useEffect(() => {
-    void desktop.settings.get().then(setSettings).catch(() => setSettings({ kubeconfigSources: [], includeStandardChain: true }));
+    void desktop.settings.get()
+      .then((loaded) => {
+        setSettings(loaded);
+        setSettingsLoaded(true);
+      })
+      .catch(() => setSettings(emptySettings));
     void desktop.app.version().then(setAppVersion).catch(() => undefined);
   }, []);
 
@@ -465,7 +489,7 @@ export default function App() {
         onRefreshSources={reloadSources}
         onApply={async (sources, includeStandardChain) => {
           await desktop.settings.applyKubeconfigSources(sources, includeStandardChain);
-          setSettings({ kubeconfigSources: sources, includeStandardChain });
+          setSettings({ kubeconfigSources: sources, includeStandardChain, welcomedAt: settings.welcomedAt });
           await reloadSources();
         }}
         onPickFile={() => desktop.settings.pickKubeconfigFile()}
@@ -514,7 +538,7 @@ export default function App() {
             ? settings.kubeconfigSources
             : [...settings.kubeconfigSources, path];
           await desktop.settings.applyKubeconfigSources(sources, settings.includeStandardChain);
-          setSettings({ kubeconfigSources: sources, includeStandardChain: settings.includeStandardChain });
+          setSettings({ kubeconfigSources: sources, includeStandardChain: settings.includeStandardChain, welcomedAt: settings.welcomedAt });
           await contexts.loadContexts();
           return path;
         }}
@@ -522,6 +546,7 @@ export default function App() {
           await desktop.contexts.renameConflict(request);
           await contexts.loadContexts();
         }}
+        onOpenExternal={(url) => void desktop.app.openExternal(url)}
       />
       {updateCard && <UpdateNotice card={updateCard} onOpenExternal={(url) => void desktop.app.openExternal(url)} />}
       </>
@@ -721,7 +746,15 @@ export default function App() {
             </Suspense>
           )}
       </div>
-      {updateCard && <UpdateNotice card={updateCard} onOpenExternal={(url) => void desktop.app.openExternal(url)} />}
+      {welcomeVisible ? (
+        <WelcomeCard
+          isMac={desktop.platform === "darwin"}
+          onDismiss={dismissWelcome}
+          onOpenExternal={(url) => void desktop.app.openExternal(url)}
+        />
+      ) : updateCard ? (
+        <UpdateNotice card={updateCard} onOpenExternal={(url) => void desktop.app.openExternal(url)} />
+      ) : null}
       <CommandPalette
         open={paletteOpen}
         onOpenChange={(open) => {

--- a/apps/desktop/src/renderer/components/WelcomeCard.tsx
+++ b/apps/desktop/src/renderer/components/WelcomeCard.tsx
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ExternalLink, Star, X } from "lucide-react";
+
+import { Kbd } from "@/components/ui/kbd";
+import { QUICKSTART_URL, REPO_URL, REPORT_URL } from "../lib/links";
+
+/**
+ * One-shot first-run card: appears the first time the user lands on the
+ * resource list and is gone forever once closed (the shell stores the stamp;
+ * the renderer decides when to show it). Teaches only the shortcuts that
+ * actually exist and the two places to get help. The dismissible-notice
+ * placement follows UpdateNotice; the two never stack — the update card
+ * defers while this one is up.
+ */
+export function WelcomeCard({
+  isMac,
+  onDismiss,
+  onOpenExternal,
+}: {
+  isMac: boolean;
+  onDismiss(): void;
+  onOpenExternal(url: string): void;
+}) {
+  return (
+    <aside className="welcome-card" data-testid="welcome-card" role="status" aria-label="Welcome to Aster">
+      <button className="welcome-card-close" data-testid="welcome-dismiss" aria-label="Dismiss welcome card" onClick={onDismiss}>
+        <X size={14} aria-hidden />
+      </button>
+      <p className="welcome-card-title">Welcome aboard</p>
+      <ul className="welcome-card-list">
+        <li>
+          <Kbd>{isMac ? "⌘K" : "Ctrl+K"}</Kbd>
+          <span>Command palette — switch clusters, jump to any resource, search the cluster</span>
+        </li>
+        <li>
+          <Kbd>{isMac ? "⌘F" : "Ctrl+F"}</Kbd>
+          <Kbd>↑↓</Kbd>
+          <Kbd>↵</Kbd>
+          <Kbd>Esc</Kbd>
+          <span>Filter the list, open a row, step back</span>
+        </li>
+        <li>
+          <button
+            type="button"
+            className="welcome-card-link"
+            data-testid="welcome-link-star"
+            onClick={() => onOpenExternal(REPO_URL)}
+          >
+            <Star size={12} aria-hidden />
+            Star on GitHub
+            <ExternalLink size={11} aria-hidden />
+          </button>
+          <span>Free way to support the project</span>
+        </li>
+        <li>
+          <button
+            type="button"
+            className="welcome-card-link"
+            data-testid="welcome-link-docs"
+            onClick={() => onOpenExternal(QUICKSTART_URL)}
+          >
+            Quickstart docs
+            <ExternalLink size={11} aria-hidden />
+          </button>
+          <span>·</span>
+          <button
+            type="button"
+            className="welcome-card-link"
+            data-testid="welcome-link-report"
+            onClick={() => onOpenExternal(REPORT_URL)}
+          >
+            Report an issue
+            <ExternalLink size={11} aria-hidden />
+          </button>
+        </li>
+      </ul>
+    </aside>
+  );
+}

--- a/apps/desktop/src/renderer/lib/desktop-tauri.ts
+++ b/apps/desktop/src/renderer/lib/desktop-tauri.ts
@@ -120,6 +120,7 @@ export function createTauriDesktopApi(): DesktopApi {
       get: () => invoke<AsterSettings>("settings_get"),
       setKubeconfigSources: (sources, includeStandardChain) =>
         invoke<AsterSettings>("settings_set_kubeconfig_sources", { sources, includeStandardChain }),
+      markWelcomed: () => invoke<AsterSettings>("settings_mark_welcomed"),
       applyKubeconfigSources: (sources, includeStandardChain) =>
         invoke<void>("settings_apply_kubeconfig_sources", { sources, includeStandardChain }),
       pickKubeconfigFile: () => invoke<string | null>("settings_pick_kubeconfig_file"),

--- a/apps/desktop/src/renderer/lib/links.ts
+++ b/apps/desktop/src/renderer/lib/links.ts
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Canonical external destinations the app links to. The Rust shell keeps its
-// own copy for the native Help menu (menu.rs): the renderer never shares
-// modules with the shell, so the two lists are kept in sync by the smoke
-// tests' URL assertions instead of a common source.
+// Canonical external destinations the renderer links to. The Rust shell
+// keeps its own copy for the native Help menu (menu.rs): the renderer never
+// shares modules with the shell, so the two lists are kept aligned by hand —
+// smoke tests cover the renderer side only.
 
 /** English canonical guide; the Chinese counterpart sits beside it. */
 export const QUICKSTART_URL = "https://github.com/zjy365/aster/blob/main/docs/quickstart.md";
 export const REPO_URL = "https://github.com/zjy365/aster";
 export const REPORT_URL = "https://github.com/zjy365/aster/issues";
+/** The author's personal profile — deliberately not the repo. */
+export const AUTHOR_X_URL = "https://x.com/zjy365";

--- a/apps/desktop/src/renderer/lib/links.ts
+++ b/apps/desktop/src/renderer/lib/links.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Canonical external destinations the app links to. The Rust shell keeps its
+// own copy for the native Help menu (menu.rs): the renderer never shares
+// modules with the shell, so the two lists are kept in sync by the smoke
+// tests' URL assertions instead of a common source.
+
+/** English canonical guide; the Chinese counterpart sits beside it. */
+export const QUICKSTART_URL = "https://github.com/zjy365/aster/blob/main/docs/quickstart.md";
+export const REPO_URL = "https://github.com/zjy365/aster";
+export const REPORT_URL = "https://github.com/zjy365/aster/issues";

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -753,6 +753,12 @@ h2 {
   text-align: center;
 }
 
+/* Full-state views (empty / loading / error) center in the whole list area;
+   the card lists keep their top-aligned grid. */
+.context-list:has(.context-picker-state) {
+  align-content: center;
+}
+
 .context-picker-state [data-slot="empty-icon"] {
   margin-bottom: 12px;
   color: var(--faint);
@@ -778,10 +784,9 @@ h2 {
    row — label, mono command, copy, docs link — under the primary CTAs. */
 .context-no-cluster {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 8px;
+  gap: 6px;
   margin-top: 14px;
   padding-top: 12px;
   border-top: 1px solid var(--border);
@@ -791,10 +796,33 @@ h2 {
   font-size: 11px;
 }
 
+.context-no-cluster-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
 .context-no-cluster > span {
   margin-top: 0;
   font-size: 11px;
   white-space: nowrap;
+}
+
+/* Inline settings entry inside the empty-state sentence: a quiet link, not a
+   second button — the titlebar gear and this link are the same destination. */
+.context-empty-inline-link {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--primary);
+  font-size: inherit;
+  cursor: pointer;
+}
+
+.context-empty-inline-link:hover {
+  text-decoration: underline;
 }
 
 .context-no-cluster-command {

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -3742,9 +3742,12 @@ h2 {
   }
 }
 
-/* Update notice card (bottom-right, fixed overlay) */
+/* Bottom-right fixed notice overlay, shared by UpdateNotice and the
+   first-run WelcomeCard (the two never render together — the update card
+   defers while the welcome card is up). */
 
-.update-notice {
+.update-notice,
+.welcome-card {
   position: fixed;
   right: 18px;
   /* Clears the 34px table footer (Load next 100 lives at its right edge). */
@@ -3759,11 +3762,16 @@ h2 {
   color: var(--text);
 }
 
+.welcome-card {
+  width: min(360px, calc(100vw - 36px));
+}
+
 .update-notice[data-state="error"] {
   border-color: var(--failed);
 }
 
-.update-notice-close {
+.update-notice-close,
+.welcome-card-close {
   position: absolute;
   top: 8px;
   right: 8px;
@@ -3778,7 +3786,8 @@ h2 {
   cursor: pointer;
 }
 
-.update-notice-close:hover {
+.update-notice-close:hover,
+.welcome-card-close:hover {
   background: var(--surface-hover);
   color: var(--text);
 }
@@ -3874,41 +3883,8 @@ h2 {
   text-align: right;
 }
 
-/* First-run welcome card: same bottom-right notice slot as UpdateNotice (the
-   two never render together — the update card defers while this is up). */
-.welcome-card {
-  position: fixed;
-  right: 18px;
-  bottom: 52px;
-  z-index: 60;
-  width: min(360px, calc(100vw - 36px));
-  padding: 14px 16px;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: var(--surface);
-  box-shadow: 0 14px 40px rgb(0 0 0 / 16%);
-  color: var(--text);
-}
-
-.welcome-card-close {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  display: grid;
-  place-items: center;
-  width: 22px;
-  height: 22px;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--faint);
-  cursor: pointer;
-}
-
-.welcome-card-close:hover {
-  color: var(--text);
-  background: var(--surface-hover);
-}
+/* First-run welcome card: the notice overlay shape comes from the shared
+   .update-notice rule above; only the list layout is its own. */
 
 .welcome-card-title {
   margin: 0 0 8px;

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -774,6 +774,73 @@ h2 {
   line-height: 1.5;
 }
 
+/* The "No cluster yet?" third path in the picker's empty state: one quiet
+   row — label, mono command, copy, docs link — under the primary CTAs. */
+.context-no-cluster {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  width: 100%;
+  max-width: 460px;
+  color: var(--faint);
+  font-size: 11px;
+}
+
+.context-no-cluster > span {
+  margin-top: 0;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.context-no-cluster-command {
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-muted);
+  color: var(--text-secondary);
+  font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+  font-size: 11px;
+}
+
+.context-no-cluster-copy,
+.context-no-cluster-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--faint);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.context-no-cluster-copy {
+  padding: 3px;
+}
+
+.context-no-cluster-copy svg,
+.context-no-cluster-link svg {
+  width: 12px;
+  height: 12px;
+}
+
+.context-no-cluster-copy:hover,
+.context-no-cluster-link:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.context-no-cluster-link {
+  padding: 3px 6px;
+  white-space: nowrap;
+}
+
 .context-picker-footer {
   display: flex;
   min-height: 44px;
@@ -3805,6 +3872,88 @@ h2 {
   font-size: 11px;
   color: var(--faint);
   text-align: right;
+}
+
+/* First-run welcome card: same bottom-right notice slot as UpdateNotice (the
+   two never render together — the update card defers while this is up). */
+.welcome-card {
+  position: fixed;
+  right: 18px;
+  bottom: 52px;
+  z-index: 60;
+  width: min(360px, calc(100vw - 36px));
+  padding: 14px 16px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  box-shadow: 0 14px 40px rgb(0 0 0 / 16%);
+  color: var(--text);
+}
+
+.welcome-card-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--faint);
+  cursor: pointer;
+}
+
+.welcome-card-close:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.welcome-card-title {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.welcome-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.welcome-card-list li {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.welcome-card-list li > span {
+  min-width: 0;
+}
+
+.welcome-card-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  border-radius: 6px;
+  padding: 2px 5px;
+  background: transparent;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.welcome-card-link:hover {
+  background: var(--surface-hover);
 }
 
 /* Overview dashboard. It lives in the workbench like a resource kind: the

--- a/apps/desktop/src/renderer/views/ContextPicker.tsx
+++ b/apps/desktop/src/renderer/views/ContextPicker.tsx
@@ -3,8 +3,11 @@ import {
   AlertTriangle,
   ArrowRight,
   Boxes,
+  Check,
   CheckCircle2,
   ClipboardPaste,
+  Copy,
+  ExternalLink,
   LayoutGrid,
   List as ListIcon,
   LoaderCircle,
@@ -39,6 +42,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { ContextLayout } from "../lib/context-picker";
+import { QUICKSTART_URL } from "../lib/links";
 import { PasteKubeconfigDialog } from "./PasteKubeconfigDialog";
 
 interface ContextPickerProps {
@@ -66,6 +70,8 @@ interface ContextPickerProps {
   onPasteKubeconfig(name: string, content: string): Promise<string>;
   /** Renames a colliding entry inside its kubeconfig file, then reloads contexts. */
   onRenameConflict(request: RenameConflictRequest): Promise<void>;
+  /** Opens an external URL (quickstart docs) in the system browser via the shell. */
+  onOpenExternal(url: string): void;
 }
 
 function ContextPicker({
@@ -87,6 +93,7 @@ function ContextPicker({
   onOpenSettings,
   onPasteKubeconfig,
   onRenameConflict,
+  onOpenExternal,
 }: ContextPickerProps) {
   const listRef = useRef<HTMLDivElement>(null);
   const [conflictDialog, setConflictDialog] = useState<ContextInfo | null>(null);
@@ -544,6 +551,7 @@ function ContextPicker({
                         <Settings data-icon="inline-start" aria-hidden="true" />
                         Open Settings
                       </Button>
+                      <NoClusterHint onOpenExternal={onOpenExternal} />
                     </>
                   )
                 }
@@ -683,6 +691,44 @@ function ContextPicker({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+    </div>
+  );
+}
+
+/**
+ * The no-clusters empty state's third path: users with nothing to paste yet
+ * get the shortest route to a first cluster — a copyable kind one-liner and
+ * the quickstart for alternatives. Quieter than the primary CTAs above it.
+ */
+function NoClusterHint({ onOpenExternal }: { onOpenExternal(url: string): void }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="context-no-cluster" data-testid="context-picker-empty-cluster">
+      <span>No cluster yet?</span>
+      <code className="context-no-cluster-command">kind create cluster</code>
+      <button
+        type="button"
+        className="context-no-cluster-copy"
+        aria-label="Copy kind create cluster command"
+        title={copied ? "Copied" : "Copy command"}
+        data-testid="context-picker-empty-copy"
+        onClick={() => {
+          void navigator.clipboard.writeText("kind create cluster");
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        }}
+      >
+        {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+      </button>
+      <button
+        type="button"
+        className="context-no-cluster-link"
+        data-testid="context-picker-empty-docs"
+        onClick={() => onOpenExternal(QUICKSTART_URL)}
+      >
+        <ExternalLink aria-hidden="true" />
+        How to get a cluster
+      </button>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/views/ContextPicker.tsx
+++ b/apps/desktop/src/renderer/views/ContextPicker.tsx
@@ -527,9 +527,22 @@ function ContextPicker({
                 icon={<Search aria-hidden="true" />}
                 title={totalContexts ? "No matching contexts" : "No contexts found"}
                 description={
-                  totalContexts
-                    ? "Try another name or cluster."
-                    : "Paste a kubeconfig to import its clusters, or add a file in Settings."
+                  totalContexts ? (
+                    "Try another name or cluster."
+                  ) : (
+                    <>
+                      Paste a kubeconfig to import its clusters, or add a file in{" "}
+                      <button
+                        type="button"
+                        className="context-empty-inline-link"
+                        onClick={onOpenSettings}
+                        data-testid="context-picker-empty-settings"
+                      >
+                        Settings
+                      </button>
+                      .
+                    </>
+                  )
                 }
                 action={
                   totalContexts ? undefined : (
@@ -541,15 +554,6 @@ function ContextPicker({
                       >
                         <ClipboardPaste data-icon="inline-start" aria-hidden="true" />
                         Paste kubeconfig
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        onClick={onOpenSettings}
-                        data-testid="context-picker-empty-settings"
-                      >
-                        <Settings data-icon="inline-start" aria-hidden="true" />
-                        Open Settings
                       </Button>
                       <NoClusterHint onOpenExternal={onOpenExternal} />
                     </>
@@ -698,28 +702,30 @@ function ContextPicker({
 /**
  * The no-clusters empty state's third path: users with nothing to paste yet
  * get the shortest route to a first cluster — a copyable kind one-liner and
- * the quickstart for alternatives. Quieter than the primary CTAs above it.
+ * the quickstart for alternatives. Quieter than the primary CTA above it.
  */
 function NoClusterHint({ onOpenExternal }: { onOpenExternal(url: string): void }) {
   const [copied, setCopied] = useState(false);
   return (
     <div className="context-no-cluster" data-testid="context-picker-empty-cluster">
-      <span>No cluster yet?</span>
-      <code className="context-no-cluster-command">kind create cluster</code>
-      <button
-        type="button"
-        className="context-no-cluster-copy"
-        aria-label="Copy kind create cluster command"
-        title={copied ? "Copied" : "Copy command"}
-        data-testid="context-picker-empty-copy"
-        onClick={() => {
-          void navigator.clipboard.writeText("kind create cluster");
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1200);
-        }}
-      >
-        {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
-      </button>
+      <span className="context-no-cluster-row">
+        <span>No cluster yet?</span>
+        <code className="context-no-cluster-command">kind create cluster</code>
+        <button
+          type="button"
+          className="context-no-cluster-copy"
+          aria-label="Copy kind create cluster command"
+          title={copied ? "Copied" : "Copy command"}
+          data-testid="context-picker-empty-copy"
+          onClick={() => {
+            void navigator.clipboard.writeText("kind create cluster");
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1200);
+          }}
+        >
+          {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+        </button>
+      </span>
       <button
         type="button"
         className="context-no-cluster-link"
@@ -745,7 +751,7 @@ function ContextState({
   tone?: "error";
   icon: ReactNode;
   title: string;
-  description: string;
+  description: ReactNode;
   action?: ReactNode;
 }) {
   return (

--- a/apps/desktop/src/renderer/views/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/views/SettingsPage.tsx
@@ -2,6 +2,7 @@
 import {
   ArrowLeft,
   AtSign,
+  BookOpen,
   Boxes,
   ClipboardPaste,
   FilePlus2,
@@ -21,6 +22,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PasteKubeconfigDialog } from "./PasteKubeconfigDialog";
+import { QUICKSTART_URL, REPO_URL } from "../lib/links";
 import {
   BUILT_IN_THEMES,
   getThemeDefinition,
@@ -74,10 +76,12 @@ const SECTION_TITLES: Record<Section, string> = {
   about: "About",
 };
 
-/** Community links pinned at the bottom of the settings sidebar. */
-const COMMUNITY_LINKS: { label: string; url: string; icon: typeof Star }[] = [
-  { label: "Star on GitHub", url: "https://github.com/zjy365", icon: Star },
-  { label: "Follow on X", url: "https://x.com/zjy365", icon: AtSign },
+/** Community links pinned at the bottom of the settings sidebar: the guide,
+ * the project on GitHub, the author on X. */
+const COMMUNITY_LINKS: { id: string; label: string; url: string; icon: typeof Star }[] = [
+  { id: "docs", label: "Quickstart", url: QUICKSTART_URL, icon: BookOpen },
+  { id: "github", label: "Star on GitHub", url: REPO_URL, icon: Star },
+  { id: "x", label: "Follow on X", url: "https://x.com/zjy365", icon: AtSign },
 ];
 
 const THEME_OPTIONS: { value: AppearanceTheme; label: string }[] = [
@@ -249,13 +253,13 @@ export function SettingsPage({
           </TabsList>
           <div className="settings-sidebar-bottom">
             <div className="settings-sidebar-links">
-              {COMMUNITY_LINKS.map(({ label, url, icon: Icon }) => (
+              {COMMUNITY_LINKS.map(({ id, label, url, icon: Icon }) => (
                 <button
                   key={url}
                   type="button"
                   className="settings-sidebar-link"
                   onClick={() => onOpenExternal(url)}
-                  data-testid={`settings-link-${label === "Star on GitHub" ? "github" : "x"}`}
+                  data-testid={`settings-link-${id}`}
                 >
                   <Icon aria-hidden="true" />
                   {label}

--- a/apps/desktop/src/renderer/views/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/views/SettingsPage.tsx
@@ -22,7 +22,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PasteKubeconfigDialog } from "./PasteKubeconfigDialog";
-import { QUICKSTART_URL, REPO_URL } from "../lib/links";
+import { AUTHOR_X_URL, QUICKSTART_URL, REPO_URL } from "../lib/links";
 import {
   BUILT_IN_THEMES,
   getThemeDefinition,
@@ -81,7 +81,7 @@ const SECTION_TITLES: Record<Section, string> = {
 const COMMUNITY_LINKS: { id: string; label: string; url: string; icon: typeof Star }[] = [
   { id: "docs", label: "Quickstart", url: QUICKSTART_URL, icon: BookOpen },
   { id: "github", label: "Star on GitHub", url: REPO_URL, icon: Star },
-  { id: "x", label: "Follow on X", url: "https://x.com/zjy365", icon: AtSign },
+  { id: "x", label: "Follow on X", url: AUTHOR_X_URL, icon: AtSign },
 ];
 
 const THEME_OPTIONS: { value: AppearanceTheme; label: string }[] = [

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -68,6 +68,12 @@ export interface AsterSettings {
    * no configured sources the app simply has no clusters.
    */
   includeStandardChain: boolean;
+  /**
+   * RFC 3339 timestamp written when the first-run welcome card is dismissed;
+   * null means never welcomed. The shell only stores it — deciding when the
+   * card shows is the renderer's.
+   */
+  welcomedAt: string | null;
 }
 
 /**
@@ -516,6 +522,8 @@ export interface DesktopApi {
   settings: {
     get(): Promise<AsterSettings>;
     setKubeconfigSources(sources: string[], includeStandardChain: boolean): Promise<AsterSettings>;
+    /** Stamps the first-run welcome dismissal (shell-side time); idempotent. */
+    markWelcomed(): Promise<AsterSettings>;
     pickKubeconfigFile(): Promise<string | null>;
     pickKubeconfigFolder(): Promise<string | null>;
     /**

--- a/apps/desktop/tests/live/shim.ts
+++ b/apps/desktop/tests/live/shim.ts
@@ -124,8 +124,11 @@ const api: DesktopApi = {
     renameConflict: async (request) => { await corePost("/v1/sources/rename", request); },
   },
   settings: {
-    get: () => Promise.resolve({ kubeconfigSources: [], includeStandardChain: false }),
-    setKubeconfigSources: (sources, includeStandardChain) => Promise.resolve({ kubeconfigSources: sources, includeStandardChain }),
+    // Live tests target the core pipeline; a pre-welcomed stamp keeps the
+    // first-run card out of their way.
+    get: () => Promise.resolve({ kubeconfigSources: [], includeStandardChain: false, welcomedAt: "2026-08-01T00:00:00Z" }),
+    setKubeconfigSources: (sources, includeStandardChain) => Promise.resolve({ kubeconfigSources: sources, includeStandardChain, welcomedAt: "2026-08-01T00:00:00Z" }),
+    markWelcomed: () => Promise.resolve({ kubeconfigSources: [], includeStandardChain: false, welcomedAt: "2026-08-01T00:00:00Z" }),
     pickKubeconfigFile: () => Promise.resolve(null),
     pickKubeconfigFolder: () => Promise.resolve(null),
     // Paste import writes through the shell filesystem; there is no shell here.

--- a/apps/desktop/tests/renderer-smoke.spec.ts
+++ b/apps/desktop/tests/renderer-smoke.spec.ts
@@ -19,6 +19,15 @@ const MOCK_DESKTOP_API = `
   const TOTAL = ${TOTAL_DEPLOYMENTS};
   const PAGE = ${PAGE_SIZE};
 
+  // The mocked settings store lives in sessionStorage so a reload (the test's
+  // stand-in for an app relaunch) reads back what markWelcomed wrote. Unset
+  // means a returning user: the welcome card stays hidden in every test that
+  // does not opt in by setting the key to "".
+  const mockWelcomedAt = () => {
+    const stored = window.sessionStorage.getItem("aster.mockWelcomedAt");
+    return stored === null ? "2026-08-01T00:00:00Z" : (stored || null);
+  };
+
   const contexts = [
     { id: "dev", name: "dev", cluster: "dev-cluster", server: "https://dev.invalid", user: "dev", namespace: "default", current: true, source: "fixture", conflicts: [{ path: "/Users/fixture/other.yaml", kind: "cluster", name: "dev-cluster", suggestion: "dev-cluster-hzh" }] },
     { id: "prod", name: "prod", cluster: "prod-cluster", server: "https://prod.invalid", user: "prod", namespace: "default", current: false, source: "fixture" },
@@ -163,8 +172,16 @@ const MOCK_DESKTOP_API = `
       renameConflict: async (request) => { window.__renamedConflict = request; },
     },
     settings: {
-      get: async () => ({ kubeconfigSources: [], includeStandardChain: true }),
-      setKubeconfigSources: async (sources, includeStandardChain) => ({ kubeconfigSources: sources, includeStandardChain }),
+      // Default is a returning user (welcomed) so the first-run card stays
+      // out of unrelated tests; the welcome-card tests opt in via
+      // sessionStorage below.
+      get: async () => ({ kubeconfigSources: [], includeStandardChain: true, welcomedAt: mockWelcomedAt() }),
+      setKubeconfigSources: async (sources, includeStandardChain) => ({ kubeconfigSources: sources, includeStandardChain, welcomedAt: mockWelcomedAt() }),
+      markWelcomed: async () => {
+        window.sessionStorage.setItem("aster.mockWelcomedAt", "2026-09-02T04:00:00Z");
+        window.__asterWelcomed = (window.__asterWelcomed || 0) + 1;
+        return { kubeconfigSources: [], includeStandardChain: true, welcomedAt: "2026-09-02T04:00:00Z" };
+      },
       applyKubeconfigSources: async () => undefined,
       pickKubeconfigFile: async () => null,
       pickKubeconfigFolder: async () => null,
@@ -1131,12 +1148,18 @@ test("settings opens as a page and returns to the picker", async ({ page }) => {
   await expect(settings).toContainText("Ready");
   await expect(settings.getByTestId("settings-check-updates")).toBeVisible();
 
-  // Community links in the sidebar hand their URLs to the shell opener.
+  // Sidebar links hand their URLs to the shell opener: the quickstart doc,
+  // the repo (star), and the author's X profile.
+  await settings.getByTestId("settings-link-docs").click();
   await settings.getByTestId("settings-link-github").click();
   await settings.getByTestId("settings-link-x").click();
   await expect
     .poll(() => page.evaluate(() => (window as unknown as { __asterOpenedUrls?: string[] }).__asterOpenedUrls ?? []))
-    .toEqual(["https://github.com/zjy365", "https://x.com/zjy365"]);
+    .toEqual([
+      "https://github.com/zjy365/aster/blob/main/docs/quickstart.md",
+      "https://github.com/zjy365/aster",
+      "https://x.com/zjy365",
+    ]);
 
   // Let the 150ms tab highlight transition settle so the screenshot shows the
   // final state instead of a mid-fade frame.
@@ -1242,6 +1265,145 @@ test("settings opens with no kubeconfig at all", async ({ page }) => {
   );
   await expectNoOverflow(page, "settings page with no kubeconfig");
   await screenshot(page, "settings-no-kubeconfig");
+  expect(failures).toEqual([]);
+});
+
+test("empty state offers the no-cluster path: copy kind command, open quickstart", async ({ page }) => {
+  // A machine with no kubeconfig at all: the picker's empty state must show
+  // the third path — a copyable kind one-liner and the quickstart link — so
+  // first-run users are not dead-ended at the paste box.
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.addInitScript(() => {
+    const desktop = (window as unknown as { __ASTER_DESKTOP__?: { contexts: Record<string, unknown> } }).__ASTER_DESKTOP__;
+    if (desktop) {
+      desktop.contexts.list = async () => [];
+      desktop.contexts.sourcesReport = async () => ({ chain: [], configured: [] });
+    }
+  });
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+
+  const hint = page.getByTestId("context-picker-empty-cluster");
+  await expect(hint).toBeVisible();
+  await expect(hint).toContainText("No cluster yet?");
+  await expect(hint.getByText("kind create cluster")).toBeVisible();
+
+  await page.getByTestId("context-picker-empty-copy").click();
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe("kind create cluster");
+
+  await page.getByTestId("context-picker-empty-docs").click();
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as { __asterOpenedUrls?: string[] }).__asterOpenedUrls ?? []))
+    .toContain("https://github.com/zjy365/aster/blob/main/docs/quickstart.md");
+
+  await expectNoOverflow(page, "picker empty state with no-cluster path");
+  await screenshot(page, "picker-empty-no-cluster");
+  expect(failures).toEqual([]);
+});
+
+test("no-cluster path stays hidden when contexts exist", async ({ page }) => {
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await expect(page.getByTestId("context-option-dev")).toBeVisible();
+  await expect(page.getByTestId("context-picker-empty-cluster")).toHaveCount(0);
+  expect(failures).toEqual([]);
+});
+
+test("welcome card appears once on first cluster entry", async ({ page }) => {
+  // A never-welcomed user: the card shows the first time a context apply
+  // lands on the workbench, teaches the real shortcuts, and is gone forever
+  // after dismissal — even across a reload (the relaunch stand-in).
+  await page.addInitScript(() => {
+    // Only seed the never-welcomed state on first load; the init script also
+    // runs after reload, where the stamp markWelcomed wrote must survive.
+    if (window.sessionStorage.getItem("aster.mockWelcomedAt") === null) {
+      window.sessionStorage.setItem("aster.mockWelcomedAt", "");
+    }
+  });
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+
+  // Still absent while on the picker: the card belongs to the workbench.
+  await expect(page.getByTestId("context-option-dev")).toBeVisible();
+  await expect(page.getByTestId("welcome-card")).toHaveCount(0);
+
+  await connectToDev(page);
+  const card = page.getByTestId("welcome-card");
+  await expect(card).toBeVisible();
+  await expect(card).toContainText("Command palette");
+  await expect(card.getByText("⌘K")).toBeVisible();
+  await expect(card.getByText("⌘F")).toBeVisible();
+  await expect(card.getByText("Filter the list, open a row, step back")).toBeVisible();
+
+  // The three external lines hand their URLs to the shell opener.
+  await page.getByTestId("welcome-link-star").click();
+  await page.getByTestId("welcome-link-docs").click();
+  await page.getByTestId("welcome-link-report").click();
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as { __asterOpenedUrls?: string[] }).__asterOpenedUrls ?? []))
+    .toEqual([
+      "https://github.com/zjy365/aster",
+      "https://github.com/zjy365/aster/blob/main/docs/quickstart.md",
+      "https://github.com/zjy365/aster/issues",
+    ]);
+
+  await expectNoOverflow(page, "workbench with welcome card");
+  await screenshot(page, "workbench-welcome");
+
+  await page.getByTestId("welcome-dismiss").click();
+  await expect(card).toHaveCount(0);
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as { __asterWelcomed?: number }).__asterWelcomed ?? 0))
+    .toBe(1);
+
+  // Relaunch: the stamp persisted, so the card never returns.
+  await page.reload();
+  await connectToDev(page);
+  await expect(page.getByTestId("welcome-card")).toHaveCount(0);
+  expect(failures).toEqual([]);
+});
+
+test("welcome card does not appear after a failed apply", async ({ page }) => {
+  // A never-welcomed user whose only context is broken: the apply gate in
+  // connectContext must keep the card out of a workbench that never opened.
+  await page.addInitScript(() => {
+    if (window.sessionStorage.getItem("aster.mockWelcomedAt") === null) {
+      window.sessionStorage.setItem("aster.mockWelcomedAt", "");
+    }
+    const desktop = (window as unknown as { __ASTER_DESKTOP__?: { contexts: Record<string, unknown> } }).__ASTER_DESKTOP__;
+    if (desktop) {
+      desktop.contexts.list = async () => [
+        { id: "broken", name: "broken", cluster: "broken-cluster", server: "https://broken.invalid", user: "u", namespace: "default", current: false, source: "fixture", error: "no such file or directory" },
+      ];
+    }
+  });
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+
+  const option = page.getByTestId("context-option-broken");
+  await expect(option).toBeVisible();
+  await expect(option).toBeDisabled();
+  await option.dblclick({ force: true });
+  await expect(page.getByTestId("workbench-shell")).toHaveCount(0);
+  await expect(page.getByTestId("welcome-card")).toHaveCount(0);
+  expect(failures).toEqual([]);
+});
+
+test("welcome card stays hidden for returning users", async ({ page }) => {
+  // The mock defaults to a welcomed (returning) user; entering a cluster
+  // must not surface the card for them.
+  const failures = collectFailures(page);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await connectToDev(page);
+  await expect(page.getByTestId("workbench-shell")).toBeVisible();
+  await expect(page.getByTestId("welcome-card")).toHaveCount(0);
   expect(failures).toEqual([]);
 });
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,9 +22,11 @@ winget install --id kind.sigs.k8s.kind
 kind create cluster
 ```
 
-Alternatives: [minikube](https://minikube.sigs.k8s.io/),
-[k3d](https://k3d.io/), or any managed cluster. All of them write a kubeconfig
-that Aster picks up automatically.
+Alternatives: [minikube](https://minikube.sigs.k8s.io/)
+(`minikube start`), [k3s](https://k3s.io/) /
+[k3d](https://k3d.io/) (`k3d cluster create`), or any managed cluster
+(EKS, GKE, AKS, …). All of them write a kubeconfig that Aster picks up
+automatically.
 
 ## 2. Add clusters to Aster
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,54 @@
+# Aster quickstart
+
+[English](quickstart.md) · [简体中文](quickstart.zh-CN.md)
+
+Aster reads the same kubeconfig that `kubectl` reads. If `kubectl get pods`
+works on your machine, Aster works — open it and pick a cluster.
+
+## 1. Get a cluster
+
+Already have one (managed EKS/GKE/AKS, a home lab, a company context)? Skip
+ahead. The fastest way to a local cluster is [kind](https://kind.sigs.k8s.io/):
+
+```bash
+# macOS
+brew install kind
+kind create cluster
+```
+
+```powershell
+# Windows
+winget install --id kind.sigs.k8s.kind
+kind create cluster
+```
+
+Alternatives: [minikube](https://minikube.sigs.k8s.io/),
+[k3d](https://k3d.io/), or any managed cluster. All of them write a kubeconfig
+that Aster picks up automatically.
+
+## 2. Add clusters to Aster
+
+- **In `~/.kube/config` or `$KUBECONFIG`?** They already appear in the cluster
+  picker on first launch. Nothing to configure.
+- **Elsewhere?** Open **Settings → Kubeconfig** and add a file, a whole folder
+  of kubeconfigs, or paste the contents of one.
+
+## 3. The keys that matter
+
+Aster is keyboard-first; menus are a fallback, not the path.
+
+| Key | Action |
+|---|---|
+| `⌘K` / `Ctrl+K` | Command palette — switch cluster, jump to any resource kind, switch namespace, search the whole cluster by name, change theme |
+| `⌘F` / `Ctrl+F` | Filter the current resource list |
+| `↑` `↓` `⏎` | Navigate and open |
+| `Esc` | Step back out, one layer at a time |
+
+From there: click any row to inspect a resource, stream its logs, or edit its
+YAML. Every write goes through a dry-run diff you have to read before it
+applies.
+
+## Getting help
+
+- Report an issue: <https://github.com/zjy365/aster/issues>
+- Source and releases: <https://github.com/zjy365/aster>

--- a/docs/quickstart.zh-CN.md
+++ b/docs/quickstart.zh-CN.md
@@ -1,0 +1,50 @@
+# Aster 快速上手
+
+[English](quickstart.md) · [简体中文](quickstart.zh-CN.md)
+
+Aster 读取的是和 `kubectl` 相同的 kubeconfig。只要你的机器上
+`kubectl get pods` 能跑通，Aster 就能用——打开它，选一个集群即可。
+
+## 1. 获得一个集群
+
+已经有集群（EKS/GKE/AKS 等托管集群、家里的小实验室、公司的 context）？直接跳到下一步。
+最快的本地集群方式是 [kind](https://kind.sigs.k8s.io/)：
+
+```bash
+# macOS
+brew install kind
+kind create cluster
+```
+
+```powershell
+# Windows
+winget install --id kind.sigs.k8s.kind
+kind create cluster
+```
+
+其他选择：[minikube](https://minikube.sigs.k8s.io/)、[k3d](https://k3d.io/)，
+或任意托管集群。它们都会写入 kubeconfig，Aster 会自动识别。
+
+## 2. 把集群加进 Aster
+
+- **在 `~/.kube/config` 或 `$KUBECONFIG` 里？** 首次启动时它们就已经出现在集群选择器里，无需任何配置。
+- **在其他位置？** 打开 **设置 → Kubeconfig**，添加单个文件、整个目录，或直接粘贴 kubeconfig 内容。
+
+## 3. 关键快捷键
+
+Aster 以键盘为主，菜单只是兜底。
+
+| 按键 | 作用 |
+|---|---|
+| `⌘K` / `Ctrl+K` | 命令面板——切换集群、直达任意资源类型、切换命名空间、按名称全集群搜索、切换主题 |
+| `⌘F` / `Ctrl+F` | 过滤当前资源列表 |
+| `↑` `↓` `⏎` | 移动与打开 |
+| `Esc` | 逐层后退 |
+
+之后：点击任意一行即可查看资源详情、拉取日志、编辑 YAML。所有写操作都会先经过
+一份需要你确认的 dry-run diff，才会真正执行。
+
+## 获取帮助
+
+- 提交问题：<https://github.com/zjy365/aster/issues>
+- 源码与发布：<https://github.com/zjy365/aster>

--- a/docs/quickstart.zh-CN.md
+++ b/docs/quickstart.zh-CN.md
@@ -22,8 +22,9 @@ winget install --id kind.sigs.k8s.kind
 kind create cluster
 ```
 
-其他选择：[minikube](https://minikube.sigs.k8s.io/)、[k3d](https://k3d.io/)，
-或任意托管集群。它们都会写入 kubeconfig，Aster 会自动识别。
+其他选择：[minikube](https://minikube.sigs.k8s.io/)（`minikube start`）、
+[k3s](https://k3s.io/) / [k3d](https://k3d.io/)（`k3d cluster create`），
+或任意托管集群（EKS、GKE、AKS 等）。它们都会写入 kubeconfig，Aster 会自动识别。
 
 ## 2. 把集群加进 Aster
 


### PR DESCRIPTION
Closes #33 #34 #35 · Spec: #32

## What changes

The experience after "download finished" was undesigned. This PR adds the three pieces the spec settled on — no wizard, no carousel, no gating:

- **#34 Empty state** — the picker's "No contexts found" gains a "No cluster yet?" path: a copyable `kind create cluster` one-liner (with ✓ feedback) and a quickstart link, following the DESIGN.md empty-state pattern.
- **#35 Welcome card** — the first time a context apply lands on the workbench, a dismissible card (UpdateNotice pattern, same notice slot) teaches the four things that matter: ⌘K palette, ⌘F / ↑↓⏎ / Esc list keys, star the repo, docs & feedback. The renderer decides when it shows; the shell only stores a `welcomedAt` stamp in config.yaml — tolerant of older files, preserved across kubeconfig source rewrites, gone forever after dismissal.
- **#33 Docs & entry points** — bilingual quickstart (`docs/quickstart.md` + `zh-CN`), settings-page links fixed (GitHub now points at the repo, X at the author's profile, new Quickstart entry), native Help menu (Quickstart Docs / Report Issue / GitHub) routed through the existing https-only opener channel.

## Verification

- `pnpm typecheck`, `pnpm test` (98), `pnpm build` ✅
- Playwright smoke 44/44, incl. 5 new cases (appear-once, dismiss-persists-across-reload, failed-apply-stays-hidden, copy+docs links, settings link targets) ✅
- `cargo test` (26, incl. welcomedAt round-trip / missing-field tolerance / idempotent stamp) + `cargo clippy` clean ✅
- `go -C core test -race` + `vet` ✅ (no core changes)
- Manual `pnpm dev` against a real kubeconfig: app booted with 8 real clusters, Help submenu present, "Quickstart Docs" opened the correct URL in the browser ✅
- Two-axis code review (standards + spec) run twice; all findings addressed or explicitly accepted (see commits)

## Notes

- UpdateNotice defers while the welcome card is up — the two never stack.
- `welcomedAt` is a timestamp (not a boolean) per the spec, for a possible future "nudge after N days"; nothing consumes the value yet.