### PR TITLE
fix(landing): keep downloads when the latest release has no installers

### DIFF
--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Typecheck
         run: pnpm --dir apps/landing typecheck
 
+      - name: Test release selection
+        run: pnpm --dir apps/landing test
+
       - name: Build static export
         run: NEXT_PUBLIC_BASE_PATH=/aster pnpm --dir apps/landing build
 

--- a/apps/landing/lib/releases.test.mjs
+++ b/apps/landing/lib/releases.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { getReleases } from './releases.ts';
+
+const release = (tag, names = [], flags = {}) => ({
+  tag_name: `v${tag}`, draft: false, prerelease: false, ...flags,
+  assets: names.map(name => ({ name, browser_download_url: `https://example.com/v${tag}/${name}` })),
+});
+const installers = ['Aster_arm64.dmg', 'Aster_x64.dmg', 'Aster_x64_en-US.msi', 'Aster_amd64.AppImage'];
+
+function mockResponses(t, responses) {
+  const urls = [];
+  t.mock.method(globalThis, 'fetch', async url => {
+    urls.push(url);
+    assert.ok(responses.length, 'unexpected API request');
+    return Response.json(responses.shift());
+  });
+  return urls;
+}
+
+test('latest release with installers is used without fetching history', async t => {
+  const urls = mockResponses(t, [release('1.0.5', installers)]);
+  const result = await getReleases();
+  assert.equal(result.version, '1.0.5');
+  assert.equal(result.releases.length, 4);
+  assert.equal(urls.length, 1);
+});
+
+test('empty 1.0.5 falls back to 1.0.4 with matching version labels and links', async t => {
+  mockResponses(t, [release('1.0.5'), [
+    release('1.0.6', installers, { draft: true }),
+    release('1.0.6-beta', installers, { prerelease: true }),
+    release('1.0.5', ['latest.json', 'Aster_arm64.dmg.sig']),
+    release('1.0.4', installers),
+  ]]);
+  const result = await getReleases();
+  assert.equal(result.version, '1.0.4');
+  assert.deepEqual(result.releases.map(r => r.id), ['macos-arm64', 'macos-x64', 'windows', 'linux']);
+  for (const item of result.releases) {
+    assert.match(item.meta, /v1\.0\.4$/);
+    assert.match(item.href, /\/v1\.0\.4\//);
+  }
+});
+
+test('search continues onto the next page', async t => {
+  const urls = mockResponses(t, [release('1.0.5'), Array.from({ length: 100 }, () => release('1.0.5')), [release('1.0.4', installers)]]);
+  assert.equal((await getReleases()).version, '1.0.4');
+  assert.match(urls[2], /page=2$/);
+});
+
+test('no packaged stable release preserves the empty result', async t => {
+  mockResponses(t, [release('1.0.5'), [release('1.0.5')]]);
+  assert.deepEqual(await getReleases(), { version: '1.0.5', releases: [] });
+});
+
+test('API errors are propagated instead of inventing download links', async t => {
+  t.mock.method(globalThis, 'fetch', async () => new Response(null, { status: 503 }));
+  await assert.rejects(getReleases(), /GitHub API returned 503/);
+});

--- a/apps/landing/lib/releases.ts
+++ b/apps/landing/lib/releases.ts
@@ -9,7 +9,7 @@ export type Release = {
 };
 
 /**
- * Fetch the platform download links from the latest GitHub release at build
+ * Fetch platform download links from the latest packaged GitHub release at build
  * time (Next.js Server Component / SSG). The GitHub API is only called during
  * `next build` (and optional ISR revalidation); the rendered page is static and
  * makes no runtime API requests, so a static host is fine.
@@ -19,7 +19,7 @@ export type Release = {
  */
 const OWNER = "zjy365";
 const REPO = "aster";
-const GITHUB_API = `https://api.github.com/repos/${OWNER}/${REPO}/releases/latest`;
+const GITHUB_API = `https://api.github.com/repos/${OWNER}/${REPO}/releases`;
 
 const ASSET_PATTERNS: {
   id: string;
@@ -61,21 +61,24 @@ export type ReleasesResult = {
   releases: Release[];
 };
 
-async function fetchLatestRelease(): Promise<{
+type GitHubRelease = {
   tag_name: string;
+  draft: boolean;
+  prerelease: boolean;
   assets: { name: string; browser_download_url: string }[];
-}> {
-  const res = await fetch(GITHUB_API, {
+};
+
+async function fetchReleases<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
     headers: { Accept: "application/vnd.github+json" },
   });
   if (!res.ok) {
-    throw new Error(`GitHub API returned ${res.status} for ${GITHUB_API}`);
+    throw new Error(`GitHub API returned ${res.status} for ${url}`);
   }
   return res.json();
 }
 
-export async function getReleases(): Promise<ReleasesResult> {
-  const release = await fetchLatestRelease();
+function platformDownloads(release: GitHubRelease): ReleasesResult {
   const version = release.tag_name.replace(/^v/, "");
 
   const releases: Release[] = [];
@@ -91,4 +94,21 @@ export async function getReleases(): Promise<ReleasesResult> {
     });
   }
   return { version, releases };
+}
+
+export async function getReleases(): Promise<ReleasesResult> {
+  const latest = platformDownloads(await fetchReleases<GitHubRelease>(`${GITHUB_API}/latest`));
+  if (latest.releases.length > 0) return latest;
+
+  // A published release may have no installers (for example, a failed build).
+  // Walk the release history until a stable version has a supported installer.
+  for (let page = 1; ; page++) {
+    const history = await fetchReleases<GitHubRelease[]>(`${GITHUB_API}?per_page=100&page=${page}`);
+    for (const release of history) {
+      if (release.draft || release.prerelease) continue;
+      const downloads = platformDownloads(release);
+      if (downloads.releases.length > 0) return downloads;
+    }
+    if (history.length < 100) return latest;
+  }
 }

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -8,7 +8,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test lib/*.test.mjs"
   },
   "dependencies": {
     "next": "^16.3.1",


### PR DESCRIPTION
When the latest GitHub release has no installers, the landing page currently shows “Not packaged yet” even when older versions are downloadable. For example, publishing the empty v1.0.5 release hides the four v1.0.4 downloads.

Keep the latest release when it has a supported installer. Otherwise, search paginated release history for a packaged stable release, skipping drafts, prereleases, and unsupported assets. Download links and version labels come from the selected release.

Validation:
- Five regression tests covering latest-release selection, v1.0.5 → v1.0.4 fallback, filtering, pagination, empty history, and API errors; added to landing CI.
- Landing typecheck and production build passed.
- Verified all four download links in the freshly built static HTML point to v1.0.4.
